### PR TITLE
chore(goreleaser): fix asset names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,7 +112,7 @@ archives:
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
-      {{ .Tag }}_
+      {{- .Tag }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
Close #31

Remove unnecessary periods.

# Test

It looks good.

https://github.com/suzuki-shunsuke/tenv/releases/tag/v1.0.7-2

```
tenv_v1.0.7-2_checksums.txt
tenv_v1.0.7-2_Darwin_arm64.tar.gz
tenv_v1.0.7-2_Darwin_x86_64.tar.gz
tenv_v1.0.7-2_Freebsd_arm64.tar.gz
tenv_v1.0.7-2_Freebsd_armv6.tar.gz
tenv_v1.0.7-2_Freebsd_i386.tar.gz
tenv_v1.0.7-2_Freebsd_x86_64.tar.gz
tenv_v1.0.7-2_Linux_arm64.tar.gz
tenv_v1.0.7-2_Linux_armv6.tar.gz
tenv_v1.0.7-2_Linux_i386.tar.gz
tenv_v1.0.7-2_Linux_x86_64.tar.gz
tenv_v1.0.7-2_Openbsd_arm64.tar.gz
tenv_v1.0.7-2_Openbsd_armv6.tar.gz
tenv_v1.0.7-2_Openbsd_i386.tar.gz
tenv_v1.0.7-2_Openbsd_x86_64.tar.gz
tenv_v1.0.7-2_Solaris_x86_64.tar.gz
tenv_v1.0.7-2_Windows_arm64.zip
tenv_v1.0.7-2_Windows_armv6.zip
tenv_v1.0.7-2_Windows_i386.zip
tenv_v1.0.7-2_Windows_x86_64.zip
```

I also confirmed this issue isn't fixed in the main branch.

https://github.com/suzuki-shunsuke/tenv/releases/tag/v1.0.7-3