### PR TITLE
Update installation instructions for cosign and tenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,20 +94,19 @@ apk add cosign
 <details><summary><b>Linux: RPM</b></summary><br>
 
 ```sh
-LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | grep tag_name | cut -d : -f2 | tr -d "v\", ")
+LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | jq -r .tag_name | tr -d "v\", ")
 curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}-1.x86_64.rpm"
 sudo rpm -ivh cosign-${LATEST_VERSION}.x86_64.rpm
 ```
 </details>
-
-
 <details><summary><b>Linux: dkpg</b></summary><br>
 
 ```sh
-LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | grep tag_name | cut -d : -f2 | tr -d "v\", ")
+LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | jq -r .tag_name | tr -d "v\", ")
 curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign_${LATEST_VERSION}_amd64.deb"
 sudo dpkg -i cosign_${LATEST_VERSION}_amd64.deb
-  ```
+```
+
 </details>
 
 
@@ -125,7 +124,13 @@ brew install tenv
 </details>
 
 <details><summary><b>Ubuntu</b></summary><br>
-TODO
+
+```sh
+LATEST_VERSION=$(curl --silent https://api.github.com/repos/tofuutils/tenv/releases/latest|jq -r .tag_name)
+curl -O -L "https://github.com/tofuutils/tenv/releases/latest/download/tenv_${LATEST_VERSION}_amd64.deb"
+sudo dpkg -i "tenv_${LATEST_VERSION}_amd64.deb"
+```
+
 </details>
 
 <a id="manual-installation"></a>
@@ -136,7 +141,7 @@ Get the most recent packaged binaries (`.deb`, `.rpm`, `.apk`, `pkg.tar.zst `, `
 #### Docker Installation
 You can use dockerized version of tenv via the following commands:
 
-```shell
+```sh
 TODO
 ```
 


### PR DESCRIPTION
- Simplify instructions for cosign to use jq instead of grep and cut
- Add installation instructions for tenv on ubuntu