### PR TITLE
docs: Adding Arch Linux installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ apk add cosign
 
 </details>
 
+<details><summary><b>ArchLinux</b></summary><br>
+
+```sh
+sudo pacman -S cosign
+```
+
+</details>
 
 <details><summary><b>Linux: RPM</b></summary><br>
 
@@ -129,6 +136,16 @@ sudo dpkg -i cosign_${LATEST_VERSION}_amd64.deb
 
 <a id="automatic-installation"></a>
 #### Automatic Installation
+<details><summary><b>ArchLinux (AUR)</b></summary><br>
+
+This package is available on the ArchLinux User Repository.
+It can be installed using the yay AUR helper:
+```sh
+yay tenv-bin
+```
+
+</details>
+
 <details><summary><b>MacOS (Homebrew)</b></summary><br>
 
 ```console

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ apk add cosign
 
 </details>
 
-<details><summary><b>ArchLinux</b></summary><br>
+<details><summary><b>Arch Linux</b></summary><br>
 
 ```sh
 sudo pacman -S cosign
@@ -136,9 +136,9 @@ sudo dpkg -i cosign_${LATEST_VERSION}_amd64.deb
 
 <a id="automatic-installation"></a>
 #### Automatic Installation
-<details><summary><b>ArchLinux (AUR)</b></summary><br>
+<details><summary><b>Arch Linux (AUR)</b></summary><br>
 
-This package is available on the ArchLinux User Repository.
+This package is available on the Arch Linux User Repository.
 It can be installed using the yay AUR helper:
 ```sh
 yay tenv-bin


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR updates the README with details on the ArchLinux installation using pacman and the AUR. 

Related to #86. 