### PR TITLE
WIP: Add  support for atmos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tenv
 terraform
 terragrunt
 tofu
+atmos

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ build: get fmt ## Build service binary.
 	go build -o tofu ./cmd/tofu
 	go build -o terraform ./cmd/terraform
 	go build -o terragrunt ./cmd/terragrunt
+	go build -o atmos ./cmd/atmos
 
 run:  ## Run service from your laptop.
 	go run ./main.go

--- a/cmd/atmos/atmos.go
+++ b/cmd/atmos/atmos.go
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2024 tofuutils authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"github.com/tofuutils/tenv/config"
+	"github.com/tofuutils/tenv/versionmanager/builder"
+	"github.com/tofuutils/tenv/versionmanager/proxy"
+)
+
+func main() {
+	proxy.Exec(builder.BuildAtmosManager, config.AtmosName)
+}

--- a/cmd/tenv/tenv.go
+++ b/cmd/tenv/tenv.go
@@ -134,10 +134,9 @@ func initRootCmd(conf *config.Config) *cobra.Command {
 	rootCmd.AddCommand(tgCmd)
 
 	atmosCmd := &cobra.Command{
-		Use:     "atmos",
-		Aliases: []string{config.AtmosName},
-		Short:   atmosHelp,
-		Long:    atmosHelp,
+		Use:   config.AtmosName,
+		Short: atmosHelp,
+		Long:  atmosHelp,
 	}
 
 	atmosParams := subCmdParams{

--- a/cmd/tenv/tenv.go
+++ b/cmd/tenv/tenv.go
@@ -39,6 +39,7 @@ const (
 	helpPrefix = "Subcommand to manage several versions of "
 	tfHelp     = helpPrefix + "Terraform (https://www.terraform.io)."
 	tgHelp     = helpPrefix + "Terragrunt (https://terragrunt.gruntwork.io)."
+	atmosHelp  = helpPrefix + "Atmos (https://atmos.tools)."
 	tofuHelp   = helpPrefix + "OpenTofu (https://opentofu.org)."
 
 	pathEnvName = "PATH"
@@ -131,6 +132,20 @@ func initRootCmd(conf *config.Config) *cobra.Command {
 	initSubCmds(tgCmd, conf, builder.BuildTgManager(conf, gruntParser), tgParams)
 
 	rootCmd.AddCommand(tgCmd)
+
+	atmosCmd := &cobra.Command{
+		Use:     "atmos",
+		Aliases: []string{config.AtmosName},
+		Short:   atmosHelp,
+		Long:    atmosHelp,
+	}
+
+	atmosParams := subCmdParams{
+		needToken: true, remoteEnvName: config.AtmosRemoteURLEnvName, pRemote: &conf.Atmos.RemoteURL,
+	}
+	initSubCmds(atmosCmd, conf, builder.BuildAtmosManager(conf, gruntParser), atmosParams)
+
+	rootCmd.AddCommand(atmosCmd)
 
 	return rootCmd
 }

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ const (
 	TerraformName  = "terraform"
 	TerragruntName = "terragrunt"
 	TofuName       = "tofu"
+	AtmosName      = "atmos"
 
 	GithubActionsEnvName = "GITHUB_ACTIONS"
 
@@ -104,6 +105,15 @@ const (
 	tofuRootPathEnvName          = tofuenvPrefix + rootPathEnvName
 	tofuTokenEnvName             = tofuenvPrefix + tokenEnvName
 	TofuVersionEnvName           = tofuenvTofuPrefix + version
+
+	atmosPrefix                   = "ATMOS_"
+	AtmosDefaultConstraintEnvName = atmosPrefix + defaultConstraint
+	AtmosDefaultVersionEnvName    = atmosPrefix + defaultVersion
+	atmosInstallModeEnvName       = atmosPrefix + installModeEnvName
+	atmosListModeEnvName          = atmosPrefix + listModeEnvName
+	atmosListURLEnvName           = atmosPrefix + listURLEnvName
+	AtmosRemoteURLEnvName         = atmosPrefix + remoteURLEnvName
+	AtmosVersionEnvName           = atmosPrefix + version
 )
 
 type Config struct {
@@ -120,6 +130,7 @@ type Config struct {
 	Tf               RemoteConfig
 	TfKeyPath        string
 	Tg               RemoteConfig
+	Atmos            RemoteConfig
 	Tofu             RemoteConfig
 	TofuKeyPath      string
 	UserPath         string
@@ -168,6 +179,7 @@ func InitConfigFromEnv() (Config, error) {
 		TfKeyPath:      os.Getenv(tfHashicorpPGPKeyEnvName),
 		Tg:             makeRemoteConfig(TgRemoteURLEnvName, tgListURLEnvName, tgInstallModeEnvName, tgListModeEnvName, defaultTerragruntGithubURL, baseGithubURL),
 		Tofu:           makeRemoteConfig(TofuRemoteURLEnvName, tofuListURLEnvName, tofuInstallModeEnvName, tofuListModeEnvName, defaultTofuGithubURL, baseGithubURL),
+		Atmos:          makeRemoteConfig(AtmosRemoteURLEnvName, atmosListURLEnvName, atmosInstallModeEnvName, atmosListModeEnvName, defaultAtmosGithubURL, baseGithubURL),
 		TofuKeyPath:    os.Getenv(tofuOpenTofuPGPKeyEnvName),
 		UserPath:       userPath,
 	}, nil
@@ -230,6 +242,7 @@ func (conf *Config) InitRemoteConf() error {
 	conf.Tf.Data = remoteConf[TerraformName]
 	conf.Tg.Data = remoteConf[TerragruntName]
 	conf.Tofu.Data = remoteConf[TofuName]
+	conf.Atmos.Data = remoteConf[AtmosName]
 
 	return nil
 }

--- a/config/remote.go
+++ b/config/remote.go
@@ -33,6 +33,7 @@ const (
 	defaultHashicorpURL        = "https://releases.hashicorp.com"
 	defaultTerragruntGithubURL = defaultGithubURL + "gruntwork-io/terragrunt" + slashReleases
 	defaultTofuGithubURL       = defaultGithubURL + "opentofu/opentofu" + slashReleases
+	defaultAtmosGithubURL      = defaultGithubURL + "cloudposse/atmos" + slashReleases
 	slashReleases              = "/releases"
 )
 

--- a/versionmanager/builder/builder.go
+++ b/versionmanager/builder/builder.go
@@ -21,6 +21,7 @@ package builder
 import (
 	"github.com/tofuutils/tenv/config"
 	"github.com/tofuutils/tenv/versionmanager"
+	atmosretriever "github.com/tofuutils/tenv/versionmanager/retriever/atmos"
 	terraformretriever "github.com/tofuutils/tenv/versionmanager/retriever/terraform"
 	terragruntretriever "github.com/tofuutils/tenv/versionmanager/retriever/terragrunt"
 	tofuretriever "github.com/tofuutils/tenv/versionmanager/retriever/tofu"
@@ -54,6 +55,19 @@ func BuildTgManager(conf *config.Config, gruntParser terragruntparser.Terragrunt
 	}
 
 	return versionmanager.Make(conf, config.TgDefaultConstraintEnvName, "Terragrunt", nil, tgRetriever, config.TgVersionEnvName, config.TgDefaultVersionEnvName, versionFiles)
+}
+
+func BuildAtmosManager(conf *config.Config, gruntParser terragruntparser.TerragruntParser) versionmanager.VersionManager {
+	atmosRetriever := atmosretriever.Make(conf)
+	versionFiles := []types.VersionFile{
+		{Name: ".atmos-version", Parser: flatparser.RetrieveVersion},
+		{Name: ".atmosswitchrc", Parser: flatparser.RetrieveVersion},
+		{Name: ".atmosswitch.toml", Parser: tomlparser.RetrieveVersion},
+		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveAtmosVersionConstraintFromHCL},
+		{Name: terragruntparser.JSONName, Parser: gruntParser.RetrieveAtmosVersionConstraintFromJSON},
+	}
+
+	return versionmanager.Make(conf, config.AtmosDefaultConstraintEnvName, "Atmos", nil, atmosRetriever, config.AtmosVersionEnvName, config.AtmosDefaultVersionEnvName, versionFiles)
 }
 
 func BuildTofuManager(conf *config.Config, gruntParser terragruntparser.TerragruntParser) versionmanager.VersionManager {

--- a/versionmanager/builder/builder.go
+++ b/versionmanager/builder/builder.go
@@ -63,8 +63,6 @@ func BuildAtmosManager(conf *config.Config, gruntParser terragruntparser.Terragr
 		{Name: ".atmos-version", Parser: flatparser.RetrieveVersion},
 		{Name: ".atmosswitchrc", Parser: flatparser.RetrieveVersion},
 		{Name: ".atmosswitch.toml", Parser: tomlparser.RetrieveVersion},
-		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveAtmosVersionConstraintFromHCL},
-		{Name: terragruntparser.JSONName, Parser: gruntParser.RetrieveAtmosVersionConstraintFromJSON},
 	}
 
 	return versionmanager.Make(conf, config.AtmosDefaultConstraintEnvName, "Atmos", nil, atmosRetriever, config.AtmosVersionEnvName, config.AtmosDefaultVersionEnvName, versionFiles)

--- a/versionmanager/builder/builder.go
+++ b/versionmanager/builder/builder.go
@@ -61,8 +61,6 @@ func BuildAtmosManager(conf *config.Config, gruntParser terragruntparser.Terragr
 	atmosRetriever := atmosretriever.Make(conf)
 	versionFiles := []types.VersionFile{
 		{Name: ".atmos-version", Parser: flatparser.RetrieveVersion},
-		{Name: ".atmosswitchrc", Parser: flatparser.RetrieveVersion},
-		{Name: ".atmosswitch.toml", Parser: tomlparser.RetrieveVersion},
 	}
 
 	return versionmanager.Make(conf, config.AtmosDefaultConstraintEnvName, "Atmos", nil, atmosRetriever, config.AtmosVersionEnvName, config.AtmosDefaultVersionEnvName, versionFiles)

--- a/versionmanager/retriever/atmos/atmosretriever.go
+++ b/versionmanager/retriever/atmos/atmosretriever.go
@@ -1,0 +1,148 @@
+/*
+ *
+ * Copyright 2024 tofuutils authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package atmosretriever
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/tofuutils/tenv/config"
+	"github.com/tofuutils/tenv/pkg/apimsg"
+	"github.com/tofuutils/tenv/pkg/download"
+	"github.com/tofuutils/tenv/pkg/github"
+	htmlretriever "github.com/tofuutils/tenv/versionmanager/retriever/html"
+)
+
+const (
+	baseFileName = "atmos_"
+	cloudposse   = "cloudposse"
+	atmos        = "atmos"
+)
+
+type AtmosRetriever struct {
+	conf *config.Config
+}
+
+func Make(conf *config.Config) AtmosRetriever {
+	return AtmosRetriever{conf: conf}
+}
+
+func (r AtmosRetriever) InstallRelease(versionStr string, targetPath string) error {
+	err := r.conf.InitRemoteConf()
+	if err != nil {
+		return err
+	}
+
+	tag := versionStr
+	// assume that atmos tags start with a 'v'
+	// and version in asset name does not
+	if tag[0] == 'v' {
+		versionStr = versionStr[1:]
+	} else {
+		tag = "v" + versionStr
+	}
+
+	var assetURLs []string
+	fileName := buildAssetName(versionStr, r.conf.Arch)
+	switch r.conf.Atmos.GetInstallMode() {
+	case config.InstallModeDirect:
+		baseAssetURL, err2 := url.JoinPath(r.conf.Atmos.GetRemoteURL(), cloudposse, config.AtmosName, github.Releases, github.Download, tag) //nolint
+		if err2 != nil {
+			return err2
+		}
+
+		assetURLs, err = htmlretriever.BuildAssetURLs(baseAssetURL, fileName)
+	case config.ModeAPI:
+		assetURLs, err = github.AssetDownloadURL(tag, []string{fileName}, r.conf.Atmos.GetRemoteURL(), r.conf.GithubToken, r.conf.Displayer.Display)
+	default:
+		return config.ErrInstallMode
+	}
+	if err != nil {
+		return err
+	}
+
+	urlTranformer := download.UrlTranformer(r.conf.Atmos.GetRewriteRule())
+	assetURLs, err = download.ApplyUrlTranformer(urlTranformer, assetURLs...)
+	if err != nil {
+		return err
+	}
+
+	data, err := download.Bytes(assetURLs[0], r.conf.Displayer.Display)
+	if err != nil {
+		return err
+	}
+
+	// dataSums, err := download.Bytes(assetURLs[1], r.conf.Displayer.Display)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// if err = sha256check.Check(data, dataSums, fileName); err != nil {
+	// 	return err
+	// }
+
+	err = os.MkdirAll(targetPath, 0755)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(targetPath, config.AtmosName), data, 0755)
+}
+
+func (r AtmosRetriever) ListReleases() ([]string, error) {
+	err := r.conf.InitRemoteConf()
+	if err != nil {
+		return nil, err
+	}
+
+	listURL := r.conf.Atmos.GetListURL()
+	switch r.conf.Atmos.GetListMode() {
+	case config.ListModeHTML:
+		baseURL, err := url.JoinPath(listURL, cloudposse, config.AtmosName, github.Releases, github.Download) //nolint
+		if err != nil {
+			return nil, err
+		}
+
+		r.conf.Displayer.Display(apimsg.MsgFetchAllReleases + baseURL)
+
+		return htmlretriever.ListReleases(baseURL, r.conf.Atmos.Data)
+	case config.ModeAPI:
+		r.conf.Displayer.Display(apimsg.MsgFetchAllReleases + listURL)
+
+		return github.ListReleases(listURL, r.conf.GithubToken)
+	default:
+		return nil, config.ErrListMode
+	}
+}
+
+func buildAssetName(version string, arch string) string {
+	var nameBuilder strings.Builder
+	nameBuilder.WriteString(baseFileName)
+	nameBuilder.WriteString(version)
+	nameBuilder.WriteByte('_')
+
+	nameBuilder.WriteString(runtime.GOOS)
+	nameBuilder.WriteByte('_')
+	nameBuilder.WriteString(arch)
+
+	return nameBuilder.String()
+}

--- a/versionmanager/semantic/parser/terragrunt/gruntparser.go
+++ b/versionmanager/semantic/parser/terragrunt/gruntparser.go
@@ -39,7 +39,6 @@ const (
 
 	terraformVersionConstraintName  = "terraform_version_constraint"
 	terragruntVersionConstraintName = "terragrunt_version_constraint"
-	atmosVersionConstraintName      = "atmos_version_constraint"
 )
 
 var terraformVersionPartialSchema = &hcl.BodySchema{ //nolint
@@ -48,10 +47,6 @@ var terraformVersionPartialSchema = &hcl.BodySchema{ //nolint
 
 var terragruntVersionPartialSchema = &hcl.BodySchema{ //nolint
 	Attributes: []hcl.AttributeSchema{{Name: terragruntVersionConstraintName}},
-}
-
-var atmosVersionPartialSchema = &hcl.BodySchema{ //nolint
-	Attributes: []hcl.AttributeSchema{{Name: atmosVersionConstraintName}},
 }
 
 type TerragruntParser struct {

--- a/versionmanager/semantic/parser/terragrunt/gruntparser.go
+++ b/versionmanager/semantic/parser/terragrunt/gruntparser.go
@@ -39,6 +39,7 @@ const (
 
 	terraformVersionConstraintName  = "terraform_version_constraint"
 	terragruntVersionConstraintName = "terragrunt_version_constraint"
+	atmosVersionConstraintName      = "atmos_version_constraint"
 )
 
 var terraformVersionPartialSchema = &hcl.BodySchema{ //nolint
@@ -47,6 +48,10 @@ var terraformVersionPartialSchema = &hcl.BodySchema{ //nolint
 
 var terragruntVersionPartialSchema = &hcl.BodySchema{ //nolint
 	Attributes: []hcl.AttributeSchema{{Name: terragruntVersionConstraintName}},
+}
+
+var atmosVersionPartialSchema = &hcl.BodySchema{ //nolint
+	Attributes: []hcl.AttributeSchema{{Name: atmosVersionConstraintName}},
 }
 
 type TerragruntParser struct {
@@ -71,6 +76,14 @@ func (p TerragruntParser) RetrieveTerragruntVersionConstraintFromHCL(filePath st
 
 func (p TerragruntParser) RetrieveTerragruntVersionConstraintFromJSON(filePath string, conf *config.Config) (string, error) {
 	return retrieveVersionConstraintFromFile(filePath, p.parser.ParseJSON, terragruntVersionPartialSchema, terragruntVersionConstraintName, conf)
+}
+
+func (p TerragruntParser) RetrieveAtmosVersionConstraintFromHCL(filePath string, conf *config.Config) (string, error) {
+	return retrieveVersionConstraintFromFile(filePath, p.parser.ParseHCL, atmosVersionPartialSchema, atmosVersionConstraintName, conf)
+}
+
+func (p TerragruntParser) RetrieveAtmosVersionConstraintFromJSON(filePath string, conf *config.Config) (string, error) {
+	return retrieveVersionConstraintFromFile(filePath, p.parser.ParseJSON, atmosVersionPartialSchema, atmosVersionConstraintName, conf)
 }
 
 func retrieveVersionConstraintFromFile(filePath string, fileParser func([]byte, string) (*hcl.File, hcl.Diagnostics), versionPartialShema *hcl.BodySchema, versionConstraintName string, conf *config.Config) (string, error) {

--- a/versionmanager/semantic/parser/terragrunt/gruntparser.go
+++ b/versionmanager/semantic/parser/terragrunt/gruntparser.go
@@ -78,14 +78,6 @@ func (p TerragruntParser) RetrieveTerragruntVersionConstraintFromJSON(filePath s
 	return retrieveVersionConstraintFromFile(filePath, p.parser.ParseJSON, terragruntVersionPartialSchema, terragruntVersionConstraintName, conf)
 }
 
-func (p TerragruntParser) RetrieveAtmosVersionConstraintFromHCL(filePath string, conf *config.Config) (string, error) {
-	return retrieveVersionConstraintFromFile(filePath, p.parser.ParseHCL, atmosVersionPartialSchema, atmosVersionConstraintName, conf)
-}
-
-func (p TerragruntParser) RetrieveAtmosVersionConstraintFromJSON(filePath string, conf *config.Config) (string, error) {
-	return retrieveVersionConstraintFromFile(filePath, p.parser.ParseJSON, atmosVersionPartialSchema, atmosVersionConstraintName, conf)
-}
-
 func retrieveVersionConstraintFromFile(filePath string, fileParser func([]byte, string) (*hcl.File, hcl.Diagnostics), versionPartialShema *hcl.BodySchema, versionConstraintName string, conf *config.Config) (string, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {


### PR DESCRIPTION
This is a quick and dirty copy&paste addition to support [atmos](https://atmos.tools) from cloudposse. Maybe someone with real Go experience can extend and merge this feature. 


tested features:
- list remote versions
- download new version
- use  version in .atmos-version
- use  version in ATMOS_VERSION env var

missing:
- not completely tested
-  no test functions

