### PR TITLE
docs: add cross reference for default constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1169,7 +1169,7 @@ Recognize same values as `tenv atmos use` command.
 <a id="required_version"></a>
 <details><summary><b>required_version</b></summary><br>
 
-the `latest-allowed` or `min-required` strategies scan through your IAC files (.tf or .tf.json) and identify a version conforming to the constraint in the relevant files. They fallback to `latest` when no IAC files and no default constraint are found.
+the `latest-allowed` or `min-required` strategies scan through your IAC files (.tf or .tf.json) and identify a version conforming to the constraint in the relevant files. They fallback to `latest` when no IAC files and no default constraint are found, and can optionally be used with a default constraint as detailed in <a href="#project-binaries">project binaries</a>.
 
 Currently the format for [Terraform required_version](https://developer.hashicorp.com/terraform/language/settings#specifying-a-required-terraform-version) and [OpenTofu required_version](https://opentofu.org/docs/language/settings#specifying-a-required-opentofu-version) are very similar, however this may change over time, always refer to docs for the latest format specification.
 
@@ -1186,6 +1186,7 @@ This would identify the latest version at or above 1.2.0 and below 2.0.0
 <a id="technical-details"></a>
 ## Technical details
 
+<a id="project-binaries"></a>
 ### Project binaries
 
 <details><summary><b>tofu</b></summary><br>


### PR DESCRIPTION
Add cross reference of option to use default constraint with `latest-allowed` or `min-required`.

Fixes: https://github.com/tofuutils/tenv/pull/124#issuecomment-2102510145