### PR TITLE
docs: add Atmos to missing descriptions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -243,7 +243,7 @@ nfpms:
     maintainer: "https://github.com/dvaumoron"
     homepage: https://github.com/tofuutils/tenv
     description: >-
-      tenv helps manage several version of OpenTofu (https://opentofu.org) and Terraform (https://www.terraform.io/),
+      tenv helps manage several version of OpenTofu (https://opentofu.org), Terraform (https://www.terraform.io/), Terragrunt (https://terragrunt.gruntwork.io), and Atmos (https://atmos.tools/),
       tenv is the managing command and tofu and terraform are proxy commands.
     license: "Apache-2.0"
     formats:
@@ -289,9 +289,9 @@ nfpms:
 #     project_source_url: https://github.com/tofuutils/tenv
 #     docs_url: https://github.com/tofuutils/tenv/blob/main/README.md
 #     tags: "terraform opentofu terragrunt tofuenv tfenv tenv"
-#     summary: OpenTofu, Terraform and Terragrunt version manager, written in Go.
+#     summary: OpenTofu, Terraform, Terragrunt, and Atmos version manager, written in Go.
 #     description: |
-#       OpenTofu, Terraform and Terragrunt version manager, written in Go.
+#       OpenTofu, Terraform, Terragrunt, and Atmos version manager, written in Go.
 #     release_notes: "https://github.com/tofuutils/tenv/releases/tag/v{{ .Version }}"
 #     dependencies:
 #       - id: nfpm

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   </a>
   <h3 align="center">tenv</h3>
   <p align="center">
-    OpenTofu, Terraform, Terragrunt and Atmos version manager, written in Go.
+    OpenTofu, Terraform, Terragrunt, and Atmos version manager, written in Go.
     <br />
     ·
     <a href="https://github.com/tofuutils/tenv/issues/new?assignees=&labels=issue%3A+bug&projects=&template=bug_report.md&title=">Report Bug</a>

--- a/cmd/tenv/tenv.go
+++ b/cmd/tenv/tenv.go
@@ -72,13 +72,13 @@ func main() {
 func initRootCmd(conf *config.Config) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     config.TenvName,
-		Long:    "tenv help manage several versions of OpenTofu (https://opentofu.org), Terraform (https://www.terraform.io) and Terragrunt (https://terragrunt.gruntwork.io).",
+		Long:    "tenv help manage several versions of OpenTofu (https://opentofu.org), Terraform (https://www.terraform.io), Terragrunt (https://terragrunt.gruntwork.io), and Atmos (https://atmos.tools/).",
 		Version: version,
 	}
 
 	flags := rootCmd.PersistentFlags()
 	flags.BoolVarP(&conf.ForceQuiet, "quiet", "q", conf.ForceQuiet, "no unnecessary output (and no log)")
-	flags.StringVarP(&conf.RootPath, "root-path", "r", conf.RootPath, "local path to install versions of OpenTofu, Terraform and Terragrunt")
+	flags.StringVarP(&conf.RootPath, "root-path", "r", conf.RootPath, "local path to install versions of OpenTofu, Terraform, Terragrunt, and Atmos")
 	flags.BoolVarP(&conf.DisplayVerbose, "verbose", "v", false, "verbose output (and set log level to Trace)")
 
 	rootCmd.AddCommand(newVersionCmd())

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,9 +1,9 @@
 
 
 name: tenv
-summary: Version manager for OpenTofu, Terraform and Terragrunt, written in Go.
+summary: Version manager for OpenTofu, Terraform, Terragrunt, and Atmos written in Go.
 description: |
-  tenv is a versatile version manager for [OpenTofu](https://opentofu.org), [Terraform](https://www.terraform.io/) and [Terragrunt](https://terragrunt.gruntwork.io/),
+  tenv is a versatile version manager for [OpenTofu](https://opentofu.org), [Terraform](https://www.terraform.io/), [Terragrunt](https://terragrunt.gruntwork.io/), and Atmos (https://atmos.tools/)
   written in Go. Our tool simplifies the complexity of handling different versions of these powerful tools,
   ensuring developers and DevOps professionals can focus on what matters most - building and deploying efficiently.
 


### PR DESCRIPTION
Adding mentions of Atmos to the descriptions where it was missed.