### PR TITLE
Update README.md For Windows Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ and Atmos, like [HCL](https://github.com/hashicorp/hcl) parsing based detection 
 
 <a id="prerequisites"></a>
 ### Prerequisites
-If you need to enable cosign checks, install `cosign` tool via one of the following commands:
+If you need to enable cosign checks, install `cosign` (v.2.0+) tool via one of the following commands:
 
 <details><summary><b>MacOS (Homebrew)</b></summary><br>
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you need to enable cosign checks, install `cosign` tool via one of the follow
 <details><summary><b>MacOS (Homebrew)</b></summary><br>
 
 ```sh
-go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+brew install cosign
 ```
 
 </details>
@@ -102,7 +102,7 @@ go install github.com/sigstore/cosign/v2/cmd/cosign@latest
 <details><summary><b>Windows (Chocolatey)</b></summary><br>
 
 ```sh
-choco install cosign
+go install github.com/sigstore/cosign/v2/cmd/cosign@latest
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you need to enable cosign checks, install `cosign` tool via one of the follow
 <details><summary><b>MacOS (Homebrew)</b></summary><br>
 
 ```sh
-brew install cosign
+go install github.com/sigstore/cosign/v2/cmd/cosign@latest
 ```
 
 </details>


### PR DESCRIPTION
Choco's latest version for cosign is 1.3.1. This isn't compatible with the current tenv build. Windows users should use go to install cosign instead