### PR TITLE
Update message when auto installation is disabled

### DIFF
--- a/versionmanager/manager.go
+++ b/versionmanager/manager.go
@@ -328,7 +328,7 @@ func (m VersionManager) Use(requestedVersion string, workingDir bool) error {
 func (m VersionManager) autoInstallDisabledMsg(version string) error {
 	cmdName := strings.ToLower(m.FolderName)
 	m.conf.Displayer.Flush(false) // Always normal display when installation is missing
-	m.conf.Displayer.Display(loghelper.Concat("Auto-install is disabled. To install ", version, " version you can set environment variable TENV_AUTO_INSTALL=true, or install it via any of the following command: 'tenv ", cmdName, " install', 'tenv ", cmdName, " install ", version, "'"))
+	m.conf.Displayer.Display(loghelper.Concat("Auto-install is disabled. To install ", version, " version you can set environment variable TENV_AUTO_INSTALL=true, or install it via following command: 'tenv ", cmdName, " install ", version, "'"))
 
 	return errNoCompatibleLocally
 }


### PR DESCRIPTION
Related to https://github.com/tofuutils/tenv/issues/172

tenv: 2.1.8

The message:
```
$ tenv tf list  
  1.2.7
  1.3.7
  1.5.5
  1.5.7
* 1.8.0 (set by /Users/nmishin/.tenv/Terraform/version)
  1.8.5
$ tenv tf use 1.2.0
Auto-install is disabled. To install 1.2.0 version you can set environment variable TENV_AUTO_INSTALL=true, or install it via any of the following command: 'tenv terraform install', 'tenv terraform install 1.2.0'
Error: no compatible version found locally
$ tenv terraform install
Resolved version from /Users/nikolai.mishin/.tenv/Terraform/version : 1.8.0
Terraform 1.8.0 already installed
```

It looks like the behavior has changed a little bit, and the message is wrong now because `tenv terraform use` doesn't update the version file.

