### PR TITLE
docs: fix rpm install line

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ sudo pacman -S cosign
 ```sh
 LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | jq -r .tag_name | tr -d "v")
 curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}-1.x86_64.rpm"
-sudo rpm -ivh cosign-${LATEST_VERSION}.x86_64.rpm
+sudo rpm -ivh cosign-${LATEST_VERSION}-1.x86_64.rpm
 ```
 
 </details>


### PR DESCRIPTION
Just a simple documentation fix

`sudo rpm -ivh cosign-${LATEST_VERSION}.x86_64.rpm` does not work because it's missing the `-1` in the filename.