### PR TITLE
fix: bump bubbletea to 1.1.2 to build with ansi 0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ProtonMail/gopenpgp/v2 v2.7.5
 	github.com/PuerkitoBio/goquery v1.10.0
 	github.com/charmbracelet/bubbles v0.20.0
-	github.com/charmbracelet/bubbletea v1.1.1
+	github.com/charmbracelet/bubbletea v1.1.2
 	github.com/charmbracelet/lipgloss v0.13.1
 	github.com/fatih/color v1.18.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
 github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
-github.com/charmbracelet/bubbletea v1.1.1 h1:KJ2/DnmpfqFtDNVTvYZ6zpPFL9iRCRr0qqKOCvppbPY=
-github.com/charmbracelet/bubbletea v1.1.1/go.mod h1:9Ogk0HrdbHolIKHdjfFpyXJmiCzGwy+FesYkZr7hYU4=
+github.com/charmbracelet/bubbletea v1.1.2 h1:naQXF2laRxyLyil/i7fxdpiz1/k06IKquhm4vBfHsIc=
+github.com/charmbracelet/bubbletea v1.1.2/go.mod h1:9HIU/hBV24qKjlehyj8z1r/tR9TYTQEag+cWZnuXo8E=
 github.com/charmbracelet/lipgloss v0.13.1 h1:Oik/oqDTMVA01GetT4JdEC033dNzWoQHdWnHnQmXE2A=
 github.com/charmbracelet/lipgloss v0.13.1/go.mod h1:zaYVJ2xKSKEnTEEbX6uAHabh2d975RJ+0yfkFpRBz5U=
 github.com/charmbracelet/x/ansi v0.4.0 h1:NqwHA4B23VwsDn4H3VcNX1W1tOmgnvY1NDx5tOXdnOU=


### PR DESCRIPTION
👋 seeing some build issue with the latest release as below:

```
# github.com/charmbracelet/bubbletea
  /home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.1/standard_renderer.go:279:24: undefined: ansi.MoveCursor
  /home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.1/standard_renderer.go:316:17: undefined: ansi.MoveCursorOrigin
  /home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.1/standard_renderer.go:346:17: undefined: ansi.MoveCursorOrigin
  /home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.1/standard_renderer.go:519:24: undefined: ansi.MoveCursor
  /home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.1/standard_renderer.go:556:23: undefined: ansi.MoveCursor
  /home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.1/standard_renderer.go:562:23: undefined: ansi.MoveCursor
  /home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.1/standard_renderer.go:583:23: undefined: ansi.MoveCursor
  /home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/charmbracelet/bubbletea@v1.1.1/standard_renderer.go:5[88](https://github.com/Homebrew/homebrew-core/actions/runs/11505864250/job/32028742807?pr=195469#step:4:89):23: undefined: ansi.MoveCursor
```

relates to https://github.com/Homebrew/homebrew-core/pull/195469