### PR TITLE
chore: bump to go1.23.2

### DIFF
--- a/.github/workflows/check-golangci-lint.yml
+++ b/.github/workflows/check-golangci-lint.yml
@@ -27,4 +27,4 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55
+          version: v1.61

--- a/.github/workflows/check-golangci-lint.yml
+++ b/.github/workflows/check-golangci-lint.yml
@@ -15,16 +15,11 @@ jobs:
     name: lint
     runs-on: ubuntu-20.04
     steps:
-      -
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      -
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
-        name: golangci-lint
+      - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.61

--- a/.github/workflows/check-golangci-lint.yml
+++ b/.github/workflows/check-golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       -
         uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version-file: "go.mod"
       -
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version-file: "go.mod"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tofuutils/tenv/v3
 
-go 1.23
+go 1.23.2
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
- update go and golangci-lint version
- update setup-go to use go.mod

cc @dvaumoron 