### PR TITLE
Revert "fix typo (#275)"

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -30,7 +30,7 @@ const ruleSize = 2
 
 type RequestOption = func(*http.Request)
 
-func ApplyURLTransformer(urlTransformer func(string) (string, error), baseURLs ...string) ([]string, error) {
+func ApplyURLTranformer(urlTransformer func(string) (string, error), baseURLs ...string) ([]string, error) {
 	transformedURLs := make([]string, 0, len(baseURLs))
 	for _, baseURL := range baseURLs {
 		transformedURL, err := urlTransformer(baseURL)
@@ -79,7 +79,7 @@ func JSON(ctx context.Context, url string, display func(string), requestOptions 
 
 func NoDisplay(string) {}
 
-func URLTransformer(rewriteRule []string) func(string) (string, error) {
+func URLTranformer(rewriteRule []string) func(string) (string, error) {
 	if len(rewriteRule) < ruleSize {
 		return noTransform
 	}

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -27,7 +27,7 @@ import (
 func TestURLTransformer(t *testing.T) {
 	t.Parallel()
 
-	urlTransformer := download.URLTransformer([]string{"https://releases.hashicorp.com", "http://localhost:8080"})
+	urlTransformer := download.URLTranformer([]string{"https://releases.hashicorp.com", "http://localhost:8080"})
 
 	value, err := urlTransformer("https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_linux_386.zip")
 	if err != nil {
@@ -42,7 +42,7 @@ func TestURLTransformer(t *testing.T) {
 func TestURLTransformerDisabled(t *testing.T) {
 	t.Parallel()
 
-	urlTransformer := download.URLTransformer(nil)
+	urlTransformer := download.URLTranformer(nil)
 
 	value, err := urlTransformer("test_value")
 	if err != nil {
@@ -57,7 +57,7 @@ func TestURLTransformerDisabled(t *testing.T) {
 func TestURLTransformerPrefix(t *testing.T) {
 	t.Parallel()
 
-	urlTransformer := download.URLTransformer([]string{"https://github.com", "https://go.dev"})
+	urlTransformer := download.URLTranformer([]string{"https://github.com", "https://go.dev"})
 
 	initialValue := "https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_darwin_amd64.zip"
 	value, err := urlTransformer(initialValue)
@@ -73,7 +73,7 @@ func TestURLTransformerPrefix(t *testing.T) {
 func TestURLTransformerSlash(t *testing.T) {
 	t.Parallel()
 
-	urlTransformer := download.URLTransformer([]string{"https://releases.hashicorp.com/", "http://localhost"})
+	urlTransformer := download.URLTranformer([]string{"https://releases.hashicorp.com/", "http://localhost"})
 
 	value, err := urlTransformer("https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_darwin_amd64.zip")
 	if err != nil {

--- a/versionmanager/retriever/html/htmlretriever.go
+++ b/versionmanager/retriever/html/htmlretriever.go
@@ -35,7 +35,7 @@ func BuildAssetURLs(baseAssetURL string, assetNames ...string) ([]string, error)
 		return url.JoinPath(baseAssetURL, assetName)
 	}
 
-	return download.ApplyURLTransformer(joinTransformer, assetNames...)
+	return download.ApplyURLTranformer(joinTransformer, assetNames...)
 }
 
 func ListReleases(ctx context.Context, baseURL string, remoteConf map[string]string, options []download.RequestOption) ([]string, error) {


### PR DESCRIPTION
This reverts commit 3c2ffc73a3db781282d6ee90ce2664f9da7d204a.

<!--
Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->