### PR TITLE
Make detached process foreground

### DIFF
--- a/versionmanager/proxy/detach/detached_others.go
+++ b/versionmanager/proxy/detach/detached_others.go
@@ -42,4 +42,5 @@ func InitBehaviorFromEnv(cmd *exec.Cmd) {
 	}
 
 	cmd.SysProcAttr.Setpgid = true
+	cmd.SysProcAttr.Foreground = true
 }


### PR DESCRIPTION
Without this flag, child process group does not become foreground and it don't control the terminal, hence stdin is not received by the child.

Fixes #255