### PR TITLE
Add error capture for GitHub rate limiting

### DIFF
--- a/pkg/apimsg/apimsg.go
+++ b/pkg/apimsg/apimsg.go
@@ -28,6 +28,7 @@ const (
 )
 
 var (
-	ErrAsset  = errors.New("searched asset not found")
-	ErrReturn = errors.New("unexpected value returned by API")
+	ErrAsset     = errors.New("searched asset not found")
+	ErrReturn    = errors.New("unexpected value returned by API")
+	ErrRateLimit = errors.New("you are rate-limited by GitHub. Consider using a token by setting the TENV_GITHUB_TOKEN env variable to increase the rate limit")
 )

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -142,12 +142,13 @@ func checkRateLimit(resp *http.Response) error {
 	if rateLimitRemaining == "0" {
 		return apimsg.ErrRateLimit
 	}
+
 	return nil
 }
 
 func downloadWithHeaders(ctx context.Context, url string, modifyRequest func(*http.Request)) (*http.Response, error) {
 	client := &http.Client{}
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -158,6 +159,7 @@ func downloadWithHeaders(ctx context.Context, url string, modifyRequest func(*ht
 	if err != nil {
 		return nil, err
 	}
+
 	return resp, nil
 }
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -20,13 +20,13 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/tofuutils/tenv/v3/pkg/apimsg"
-	"github.com/tofuutils/tenv/v3/pkg/download"
 	versionfinder "github.com/tofuutils/tenv/v3/versionmanager/semantic/finder"
 )
 
@@ -113,13 +113,52 @@ func ListReleases(ctx context.Context, githubReleaseURL string, githubToken stri
 }
 
 func apiGetRequest(ctx context.Context, callURL string, authorizationHeader string) (any, error) {
-	return download.JSON(ctx, callURL, download.NoDisplay, func(request *http.Request) {
+	resp, err := downloadWithHeaders(ctx, callURL, func(request *http.Request) {
 		request.Header.Set("Accept", "application/vnd.github+json")
 		if authorizationHeader != "" {
 			request.Header.Set("Authorization", authorizationHeader)
 		}
 		request.Header.Set("X-GitHub-Api-Version", "2022-11-28") //nolint
 	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := checkRateLimit(resp); err != nil {
+		return nil, err
+	}
+
+	var result any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, apimsg.ErrReturn
+	}
+
+	return result, nil
+}
+
+func checkRateLimit(resp *http.Response) error {
+	rateLimitRemaining := resp.Header.Get("X-Ratelimit-Remaining")
+	if rateLimitRemaining == "0" {
+		return apimsg.ErrRateLimit
+	}
+	return nil
+}
+
+func downloadWithHeaders(ctx context.Context, url string, modifyRequest func(*http.Request)) (*http.Response, error) {
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if modifyRequest != nil {
+		modifyRequest(req)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func buildAuthorizationHeader(token string) string {


### PR DESCRIPTION
Added basic capture of GitHub rate limit.
If header X-Ratelimit-Remaining equal to zero, means we are rate limited.
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit