### PR TITLE
Use asdf plugin names in tests, and in specific, fix opentofu parsing in asdf parser

### DIFF
--- a/versionmanager/semantic/parser/asdf/asdfparser.go
+++ b/versionmanager/semantic/parser/asdf/asdfparser.go
@@ -34,9 +34,10 @@ import (
 )
 
 const ToolFileName = ".tool-versions"
+const TofuAsdfPluginName = "opentofu"
 
 func RetrieveTofuVersion(filePath string, conf *config.Config) (string, error) {
-	return retrieveVersionFromToolFile(filePath, cmdconst.TofuName, conf)
+	return retrieveVersionFromToolFile(filePath, TofuAsdfPluginName, conf)
 }
 
 func RetrieveTfVersion(filePath string, conf *config.Config) (string, error) {

--- a/versionmanager/semantic/parser/asdf/asdfparser_test.go
+++ b/versionmanager/semantic/parser/asdf/asdfparser_test.go
@@ -35,8 +35,8 @@ func TestParseVersionFromToolFileReader(t *testing.T) {
 	t.Run("BasicLine", func(t *testing.T) {
 		t.Parallel()
 
-		version := parseVersionFromToolFileReader("", bytes.NewReader(toolFileData), "nodejs", loghelper.InertDisplayer)
-		if version != "10.15.0" {
+		version := parseVersionFromToolFileReader("", bytes.NewReader(toolFileData), "atmos", loghelper.InertDisplayer)
+		if version != "1.130.0" {
 			t.Fatal("Unexpected version : ", version)
 		}
 	})
@@ -44,8 +44,8 @@ func TestParseVersionFromToolFileReader(t *testing.T) {
 	t.Run("LineWithComment", func(t *testing.T) {
 		t.Parallel()
 
-		version := parseVersionFromToolFileReader("", bytes.NewReader(toolFileData), "ruby", loghelper.InertDisplayer)
-		if version != "2.5.3" {
+		version := parseVersionFromToolFileReader("", bytes.NewReader(toolFileData), "opentofu", loghelper.InertDisplayer)
+		if version != "1.8.7" {
 			t.Fatal("Unexpected version : ", version)
 		}
 	})
@@ -53,8 +53,8 @@ func TestParseVersionFromToolFileReader(t *testing.T) {
 	t.Run("LineFallback", func(t *testing.T) {
 		t.Parallel()
 
-		version := parseVersionFromToolFileReader("", bytes.NewReader(toolFileData), "python", loghelper.InertDisplayer)
-		if version != "3.7.2" {
+		version := parseVersionFromToolFileReader("", bytes.NewReader(toolFileData), "terragrunt", loghelper.InertDisplayer)
+		if version != "0.71.1" {
 			t.Fatal("Unexpected version : ", version)
 		}
 	})

--- a/versionmanager/semantic/parser/asdf/testdata/.tool-versions
+++ b/versionmanager/semantic/parser/asdf/testdata/.tool-versions
@@ -1,4 +1,4 @@
-ruby 2.5.3# This is a comment
+atmos 1.130.0# This is a comment
 # This is another comment
-nodejs 10.15.0
-python 3.7.2 2.7.15
+opentofu 1.8.6
+terragrunt 0.71.1 2.7.15


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR should fix opentofu parsing in asdf parser. The asdf `.tool-versions` file uses the plugin name. For opentofu, the plugin is named "opentofu" rather than "tofu" so we must stick to the convention already in-use.

Additionally, it seemed silly to have asdf parsing tests for tenv to be checking asdf plugins which aren't related to the requested feature which brought about this code and the bug. So I've updated the tests and test data to use tenv tools only: atmos, opentofu and terragrunt. I thought of adding a test for terraform as well but felt it was probably beyond the scope of this bugfix.