### PR TITLE
Check for CI variable when determining whether to foreground processe…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ const (
 
 	archEnvName        = "ARCH"
 	autoInstallEnvName = "AUTO_INSTALL"
+	CiEnvName          = "CI"
 	DefaultConstraint  = "DEFAULT_CONSTRAINT"
 	DefaultVersion     = "DEFAULT_" + Version
 	forceRemoteEnvName = "FORCE_REMOTE"

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ const (
 
 	archEnvName        = "ARCH"
 	autoInstallEnvName = "AUTO_INSTALL"
-        PipelineWsEnvName  = "PIPELINE_WORKSPACE"
+	PipelineWsEnvName  = "PIPELINE_WORKSPACE"
 	CiEnvName          = "CI"
 	DefaultConstraint  = "DEFAULT_CONSTRAINT"
 	DefaultVersion     = "DEFAULT_" + Version

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ const (
 
 	archEnvName        = "ARCH"
 	autoInstallEnvName = "AUTO_INSTALL"
+        PipelineWsEnvName  = "PIPELINE_WORKSPACE"
 	CiEnvName          = "CI"
 	DefaultConstraint  = "DEFAULT_CONSTRAINT"
 	DefaultVersion     = "DEFAULT_" + Version

--- a/versionmanager/proxy/detach/detached_others.go
+++ b/versionmanager/proxy/detach/detached_others.go
@@ -31,6 +31,7 @@ import (
 
 const msgCiErr = "Failed to read " + config.CiEnvName + " environment variable, disable behavior :"
 const msgErr = "Failed to read " + config.TenvDetachedProxyEnvName + " environment variable, disable behavior :"
+const msgPipelineWsErr = "Failed to read " + config.PipelineWsEnvName + " environment variable, disable behavior :"
 
 func InitBehaviorFromEnv(cmd *exec.Cmd, getenv configutils.GetenvFunc) {
 	ciEnv, ciErr := getenv.Bool(false, config.CiEnvName)
@@ -41,7 +42,11 @@ func InitBehaviorFromEnv(cmd *exec.Cmd, getenv configutils.GetenvFunc) {
 	if err != nil {
 		fmt.Println(msgErr, err) //nolint
 	}
-	if ciEnv || !detached {
+	pipelineWsEnv, pipelineWsErr := getenv.Bool(false, config.PipelineWsEnvName)
+	if pipelineWsErr != nil {
+		fmt.Println(msgPipelineWsErr, pipelineWsErr) //nolint
+	}
+	if ciEnv || pipelineWsEnv || !detached {
 		return
 	}
 

--- a/versionmanager/proxy/detach/detached_others.go
+++ b/versionmanager/proxy/detach/detached_others.go
@@ -33,7 +33,7 @@ const msgCiErr = "Failed to read " + config.CiEnvName + " environment variable, 
 const msgErr = "Failed to read " + config.TenvDetachedProxyEnvName + " environment variable, disable behavior :"
 
 func InitBehaviorFromEnv(cmd *exec.Cmd, getenv configutils.GetenvFunc) {
-	ci, ciErr := getenv.Bool(false, config.CiEnvName)
+	ciEnv, ciErr := getenv.Bool(false, config.CiEnvName)
 	if ciErr != nil {
 		fmt.Println(msgCiErr, ciErr) //nolint
 	}
@@ -41,7 +41,7 @@ func InitBehaviorFromEnv(cmd *exec.Cmd, getenv configutils.GetenvFunc) {
 	if err != nil {
 		fmt.Println(msgErr, err) //nolint
 	}
-	if ci || !detached {
+	if ciEnv || !detached {
 		return
 	}
 

--- a/versionmanager/proxy/detach/detached_others.go
+++ b/versionmanager/proxy/detach/detached_others.go
@@ -32,11 +32,15 @@ import (
 const msgErr = "Failed to read " + config.TenvDetachedProxyEnvName + " environment variable, disable behavior :"
 
 func InitBehaviorFromEnv(cmd *exec.Cmd, getenv configutils.GetenvFunc) {
+        ci, ciErr := getenv.Bool(false, config.TenvCiEnvName)
+        if ciErr != nil {
+                fmt.println(msgErr, ciErr) //nolint
+        }
 	detached, err := getenv.Bool(true, config.TenvDetachedProxyEnvName)
 	if err != nil {
 		fmt.Println(msgErr, err) //nolint
 	}
-	if !detached {
+	if ci || !detached {
 		return
 	}
 

--- a/versionmanager/proxy/detach/detached_others.go
+++ b/versionmanager/proxy/detach/detached_others.go
@@ -29,13 +29,14 @@ import (
 	configutils "github.com/tofuutils/tenv/v4/config/utils"
 )
 
+const msgCiErr = "Failed to read " + config.CiEnvName + " environment variable, disable behavior :"
 const msgErr = "Failed to read " + config.TenvDetachedProxyEnvName + " environment variable, disable behavior :"
 
 func InitBehaviorFromEnv(cmd *exec.Cmd, getenv configutils.GetenvFunc) {
-        ci, ciErr := getenv.Bool(false, config.TenvCiEnvName)
-        if ciErr != nil {
-                fmt.println(msgErr, ciErr) //nolint
-        }
+	ci, ciErr := getenv.Bool(false, config.CiEnvName)
+	if ciErr != nil {
+		fmt.Println(msgCiErr, ciErr) //nolint
+	}
 	detached, err := getenv.Bool(true, config.TenvDetachedProxyEnvName)
 	if err != nil {
 		fmt.Println(msgErr, err) //nolint


### PR DESCRIPTION
…s and ignore the value of DETACH_PROXY if we're in CI

<!--
Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR checks for the presence of the environment variable `CI`. If set to true, ignores the value of `TENV_DETACHED_PROXY` in order to avoid breaking CI pipelines.