### PR TITLE
feat: re-configure goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -411,6 +411,134 @@ checksum:
   name_template: "{{ .ProjectName }}_{{ .Tag }}_checksums.txt"
   algorithm: sha256
 
+dmg:
+  - # ID of the resulting image.
+    #
+    # Default: the project name.
+    id: foo
+
+    # Filename of the image (without the extension).
+    #
+    # Default: '{{.ProjectName}}_{{.Arch}}'.
+    # Templates: allowed.
+    name: "myproject-{{.Arch}}"
+
+    # IDs of the archives to use.
+    # Empty means all IDs.
+    ids:
+      - foo
+      - bar
+
+    # Which kind of artifact to use.
+    #
+    # Valid options are:
+    # - 'binary':    binary
+    # - 'appbundle': app bundles
+    #
+    # Default: 'binary'
+    # This feature is only available in GoReleaser Pro..
+    # Since: v2.4.
+    use: appbundle
+
+    # Allows to further filter the artifacts.
+    #
+    # Artifacts that do not match this expression will be ignored.
+    #
+    # This feature is only available in GoReleaser Pro..
+    # Since: v2.4.
+    # Templates: allowed.
+    if: '{{ eq .Os "linux" }}'
+
+    # GOAMD64 to specify which amd64 version to use if there are multiple
+    # versions from the build section.
+    #
+    # Default: v1.
+    goamd64: v1
+
+    # More files that will be available in the context in which the image
+    # will be built.
+    extra_files:
+      - logo.ico
+      - glob: ./docs/*.md
+      - glob: ./single_file.txt
+        # Templates: allowed.
+        # Note that this only works if glob matches exactly 1 file.
+        name_template: file.txt
+
+    # Additional templated extra files to add to the DMG.
+    # Those files will have their contents pass through the template engine,
+    # and its results will be added to the image as it would with the
+    # extra_files field above.
+    #
+    # This feature is only available in GoReleaser Pro..
+    # Since: v2.4.
+    # Templates: allowed.
+    templated_extra_files:
+      - src: LICENSE.tpl
+        dst: LICENSE.txt
+        mode: 0644
+
+    # Whether to remove the archives from the artifact list.
+    # If left as false, your end release will have both the archives and the
+    # dmg files.
+    replace: true
+
+    # Set the modified timestamp on the output image, typically
+    # you would do this to ensure a build was reproducible. Pass an
+    # empty string to skip modifying the output.
+    #
+    # Templates: allowed.
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+msi:
+  - # ID of the resulting installer.
+    #
+    # Default: the project name.
+    id: foo
+
+    # Filename of the installer (without the extension).
+    #
+    # Default: '{{.ProjectName}}_{{.MsiArch}}'.
+    # Templates: allowed.
+    name: "myproject-{{.MsiArch}}"
+
+    # The WXS file used to create the installers.
+    # The file contents go through the templating engine, so you can do things
+    # like `{{.Version}}` inside of it.
+    #
+    # Templates: allowed.
+    # Required.
+    wxs: ./windows/app.wsx
+
+    # IDs of the archives to use.
+    # Empty means all IDs.
+    ids:
+      - foo
+      - bar
+
+    # GOAMD64 to specify which amd64 version to use if there are multiple
+    # versions from the build section.
+    #
+    # Default: v1.
+    goamd64: v1
+
+    # More files that will be available in the context in which the installer
+    # will be built.
+    extra_files:
+      - logo.ico
+
+    # Whether to remove the archives from the artifact list.
+    # If left as false, your end release will have both the zip and the msi
+    # files.
+    replace: true
+
+    # Set the modified timestamp on the output installer, typically
+    # you would do this to ensure a build was reproducible.
+    # Pass an empty string to skip modifying the output.
+    #
+    # Templates: allowed.
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
 nfpms:
   - file_name_template: "{{ .ProjectName }}_{{- .Tag }}_{{ .Arch }}"
     maintainer: "https://github.com/dvaumoron"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,31 @@
 project_name: tenv
 version: 2
 
+announce:
+  linkedin:
+    enabled: true
+    message_template: "🎉 tenv {{.Tag}} is available now!! See what's new here - https://github.com/aquasecurity/tenv/releases/tag/{{.Tag}}"
+
+  slack:
+    enabled: true
+    message_template: ":tada: tenv {{.Tag}} is available now!! See what's new here - https://github.com/aquasecurity/tenv/releases/tag/{{.Tag}}"
+    channel: "#tofuutils"
+    username: ""
+    icon_emoji: ""
+    icon_url: ""
+    blocks: []
+    attachments: []
+
+  telegram:
+    enabled: true
+    chat_id: 123456
+    message_template: "🎉 tenv {{.Tag}} is available now!! See what's new here - https://github.com/aquasecurity/tenv/releases/tag/{{.Tag}}"
+    parse_mode: HTML # MarkdownV2
+
+  twitter:
+    enabled: true
+    message_template: "🎉 tenv {{.Tag}} is available now!! See what's new here - https://github.com/aquasecurity/tenv/releases/tag/{{.Tag}} #tenv #terraform #opentofu"
+
 before:
   hooks:
     - go mod tidy
@@ -353,10 +378,31 @@ archives:
 
 release:
   name_template: "Release {{.Tag}}"
+  discussion_category_name: Release
+  prerelease: auto
 
 changelog:
-  use: github-native
+  use: github
   sort: asc
+  format: "{{.SHA}}: {{.Message}} (@{{.AuthorUsername}})"
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "Bug fixes"
+      regexp: '^.*?bug(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+      groups:
+        - title: "Docs"
+          regex: ".*docs.*"
+          order: 1
+        - title: "CI"
+          regex: ".*build.*"
+          order: 2
+
+  divider: "---"
   filters:
     exclude:
       - "^test:"
@@ -398,6 +444,14 @@ nfpms:
     archlinux:
       pkgbase: tenv
       packager: tofuutils <tofuutils@gmail.com>
+
+cloudsmiths:
+  - organization: tofuutils
+    repository: tenv
+    distributions:
+      deb: "ubuntu/xenial"
+      alpine: "alpine/v3.8"
+      rpm: "el/7"
 
 snapcrafts:
   - name: tenv


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

TODO list:

- [ ] add `LINKEDIN_ACCESS_TOKEN` to CICD secrets
- [x] create slack app, request an access for it  (done in scope of another MR)
- [x] add `SLACK_WEBHOOK` to CICD secrets (done in scope of another MR)
- [x] add `TELEGRAM_TOKEN` to CICD secrets (done in scope of another MR)
- [ ] add `TWITTER_CONSUMER_KEY`, `TWITTER_CONSUMER_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET` to CICD secrets
- [x] add `CLOUDSMITH_TOKEN` to CICD secrets (done in scope of another MR)
- [x] create CloudSmith repository (done in scope of another MR)
- [x] switch to Goreleaser PRO (we have the license but have to change github action) (done in scope of another MR)
- [ ] finish DMG/MSI configuration
- [x] Create "release" discussion topic