### PR TITLE
Update check golangci-lint GH action

### DIFF
--- a/.github/workflows/check-codecov.yml
+++ b/.github/workflows/check-codecov.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   codecov:
     name: 'CodeCov'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/check-codespell.yml
+++ b/.github/workflows/check-codespell.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   codespell:
     name: 'Check for spelling errors'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/check-golangci-lint.yml
+++ b/.github/workflows/check-golangci-lint.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/check-golangci-lint.yml
+++ b/.github/workflows/check-golangci-lint.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.64.5

--- a/.github/workflows/create-new-release-tag.yml
+++ b/.github/workflows/create-new-release-tag.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   create-new-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-choco.yml
+++ b/.github/workflows/publish-choco.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: 'Checkout tofuutils/chocolatey-packages'

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Download tenv tarballs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   goreleaser:
     name: "Build and release packages"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write # For cosign
       packages: write # For GHCR


### PR DESCRIPTION
Update ubuntu-20.04 as deprecated;
Switch ubuntu-latest to the ubuntu-24.04;
Bump golangci version to the v1.64.5;