### PR TITLE
Include more linux distributives to the cloudsmiths config

### DIFF
--- a/.goreleaser_release_only.yml
+++ b/.goreleaser_release_only.yml
@@ -19,9 +19,21 @@ cloudsmiths:
   - organization: tofuutils
     repository: tenv
     distributions:
-      deb: "ubuntu/xenial"
-      alpine: "alpine/v3.8"
+      deb: "ubuntu/focal"
+      alpine: "alpine/v3.7"
       rpm: "el/7"
+  - organization: tofuutils
+    repository: tenv
+    distributions:
+      deb: "ubuntu/jammy"
+      alpine: "alpine/v3.8"
+      rpm: "el/8"
+  - organization: tofuutils
+    repository: tenv
+    distributions:
+      deb: "ubuntu/noble"
+      alpine: "alpine/v3.9"
+      rpm: "el/9"
 
 aurs:
   - name: tenv-bin


### PR DESCRIPTION
Added three latest versions if Ubuntu, RH, and Alpine.