### PR TITLE
Fix goreleaser deprecations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -336,7 +336,8 @@ signs:
     id: gpg
 
 archives:
-  - format: tar.gz
+  - formats:
+      - 'tar.gz'
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -349,7 +350,8 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - 'zip'
 
 release:
   name_template: "Release {{.Tag}}"


### PR DESCRIPTION
since v2.6:
DEPRECATED: archives.format
DEPRECATED: archives.format_overrides.format