### PR TITLE
Disable deprecated tenv linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - gci
     - lll
     - gocognit
+    - tenv
 
 linters-settings:
   gosimple:


### PR DESCRIPTION
tenv linter is replaced by usetesting.