### PR TITLE
feat: update versionmanager to support root.hcl files

### DIFF
--- a/.changelog/369.txt
+++ b/.changelog/369.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add root.hcl file parsing
+```

--- a/README.md
+++ b/README.md
@@ -1390,9 +1390,14 @@ Recognize same values as `tenv tg use` command.
 
 
 <a id="terragrunt-hcl-file"></a>
-<details><summary><b>terragrunt.hcl file</b></summary><br>
+<details><summary><b>terragrunt.hcl or root.hcl file</b></summary><br>
 
-If you have a terragrunt.hcl or terragrunt.hcl.json in the working directory, one of its parent directory, or user home directory, **tenv** will read constraint from `terraform_version_constraint` or `terragrunt_version_constraint` field in it (depending on proxy or subcommand used).
+[Terragrunt now recommends](https://terragrunt.gruntwork.io/docs/migrate/migrating-from-root-terragrunt-hcl/) using `root.hcl` instead of `terragrunt.hcl` as the root configuration file name.
+
+If a `terragrunt.hcl`, `root.hcl`, or their `.json` equivalents exist in the working directory, a parent directory, or the user home directory, **tenv** will read constraints from the `terraform_version_constraint` or `terragrunt_version_constraint` field (depending on proxy or subcommand used).
+
+
+If both `root.hcl` and `terragrunt.hcl` (or their `.json` versions) are present, `terragrunt.hcl` takes precedence.
 
 </details>
 
@@ -1440,6 +1445,8 @@ The version resolution order is :
 - `.tool-versions` [file](https://asdf-vm.com/manage/configuration.html#tool-versions)
 - `terraform_version_constraint` from `terragrunt.hcl` file
 - `terraform_version_constraint` from `terragrunt.hcl.json` file
+- `terraform_version_constraint` from `root.hcl` file
+- `terraform_version_constraint` from `root.hcl.json` file
 - TOFUENV_TOFU_DEFAULT_VERSION environment variable
 - `${TENV_ROOT}/OpenTofu/version` file (can be written with `tenv tofu use`)
 - `latest-allowed`
@@ -1460,6 +1467,8 @@ The version resolution order is :
 - `.tool-versions` [file](https://asdf-vm.com/manage/configuration.html#tool-versions)
 - `terraform_version_constraint` from `terragrunt.hcl` file
 - `terraform_version_constraint` from `terragrunt.hcl.json` file
+- `terraform_version_constraint` from `root.hcl` file
+- `terraform_version_constraint` from `root.hcl.json` file
 - TFENV_TERRAFORM_DEFAULT_VERSION environment variable
 - `${TENV_ROOT}/Terraform/version` file (can be written with `tenv tf use`)
 - `latest-allowed`
@@ -1482,6 +1491,8 @@ The version resolution order is :
 - `.tool-versions` [file](https://asdf-vm.com/manage/configuration.html#tool-versions)
 - `terragrunt_version_constraint` from `terragrunt.hcl` file
 - `terragrunt_version_constraint` from `terragrunt.hcl.json` file
+- `terragrunt_version_constraint` from `root.hcl` file
+- `terragrunt_version_constraint` from `root.hcl.json` file
 - TG_DEFAULT_VERSION environment variable
 - `${TENV_ROOT}/Terragrunt/version` file (can be written with `tenv tg use`)
 - `latest-allowed`
@@ -1520,6 +1531,8 @@ The version resolution order is :
 - `tofu` version from `.tool-versions` [file](https://asdf-vm.com/manage/configuration.html#tool-versions)
 - `terraform_version_constraint` from `terragrunt.hcl` file (launch `tofu`)
 - `terraform_version_constraint` from `terragrunt.hcl.json` file (launch `tofu`)
+- `terraform_version_constraint` from `root.hcl` file (launch `tofu`)
+- `terraform_version_constraint` from `root.hcl.json` file (launch `tofu`)
 - `.terraform-version` file (launch `terraform`)
 - `.tfswitchrc` file  (launch `terraform`)
 - `terraform` version from `.tool-versions` [file](https://asdf-vm.com/manage/configuration.html#tool-versions)

--- a/versionmanager/builder/builder.go
+++ b/versionmanager/builder/builder.go
@@ -64,8 +64,8 @@ func BuildTfManager(conf *config.Config, hclParser *hclparse.Parser) versionmana
 		{Name: ".tfswitchrc", Parser: flatparser.RetrieveVersion},
 		{Name: asdfparser.ToolFileName, Parser: asdfparser.RetrieveTfVersion},
 		{Name: terragruntparser.HCLNameLegacy, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
-		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
 		{Name: terragruntparser.JSONNameLegacy, Parser: gruntParser.RetrieveTerraformVersionConstraintFromJSON},
+		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
 		{Name: terragruntparser.JSONName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromJSON},
 	}
 
@@ -86,8 +86,8 @@ func BuildTgManager(conf *config.Config, hclParser *hclparse.Parser) versionmana
 		{Name: ".tgswitch.toml", Parser: tomlparser.RetrieveVersion},
 		{Name: asdfparser.ToolFileName, Parser: asdfparser.RetrieveTgVersion},
 		{Name: terragruntparser.HCLNameLegacy, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromHCL},
-		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromHCL},
 		{Name: terragruntparser.JSONNameLegacy, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromJSON},
+		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromHCL},
 		{Name: terragruntparser.JSONName, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromJSON},
 	}
 
@@ -101,8 +101,8 @@ func BuildTofuManager(conf *config.Config, hclParser *hclparse.Parser) versionma
 		{Name: ".opentofu-version", Parser: flatparser.RetrieveVersion},
 		{Name: asdfparser.ToolFileName, Parser: asdfparser.RetrieveTofuVersion},
 		{Name: terragruntparser.HCLNameLegacy, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
-		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
 		{Name: terragruntparser.JSONNameLegacy, Parser: gruntParser.RetrieveTerraformVersionConstraintFromJSON},
+		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
 		{Name: terragruntparser.JSONName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromJSON},
 	}
 

--- a/versionmanager/builder/builder.go
+++ b/versionmanager/builder/builder.go
@@ -63,7 +63,9 @@ func BuildTfManager(conf *config.Config, hclParser *hclparse.Parser) versionmana
 		{Name: ".terraform-version", Parser: flatparser.RetrieveVersion},
 		{Name: ".tfswitchrc", Parser: flatparser.RetrieveVersion},
 		{Name: asdfparser.ToolFileName, Parser: asdfparser.RetrieveTfVersion},
+		{Name: terragruntparser.HCLNameLegacy, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
 		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
+		{Name: terragruntparser.JSONNameLegacy, Parser: gruntParser.RetrieveTerraformVersionConstraintFromJSON},
 		{Name: terragruntparser.JSONName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromJSON},
 	}
 
@@ -83,7 +85,9 @@ func BuildTgManager(conf *config.Config, hclParser *hclparse.Parser) versionmana
 		{Name: ".tgswitchrc", Parser: flatparser.RetrieveVersion},
 		{Name: ".tgswitch.toml", Parser: tomlparser.RetrieveVersion},
 		{Name: asdfparser.ToolFileName, Parser: asdfparser.RetrieveTgVersion},
+		{Name: terragruntparser.HCLNameLegacy, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromHCL},
 		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromHCL},
+		{Name: terragruntparser.JSONNameLegacy, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromJSON},
 		{Name: terragruntparser.JSONName, Parser: gruntParser.RetrieveTerragruntVersionConstraintFromJSON},
 	}
 
@@ -96,7 +100,9 @@ func BuildTofuManager(conf *config.Config, hclParser *hclparse.Parser) versionma
 	versionFiles := []types.VersionFile{
 		{Name: ".opentofu-version", Parser: flatparser.RetrieveVersion},
 		{Name: asdfparser.ToolFileName, Parser: asdfparser.RetrieveTofuVersion},
+		{Name: terragruntparser.HCLNameLegacy, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
 		{Name: terragruntparser.HCLName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromHCL},
+		{Name: terragruntparser.JSONNameLegacy, Parser: gruntParser.RetrieveTerraformVersionConstraintFromJSON},
 		{Name: terragruntparser.JSONName, Parser: gruntParser.RetrieveTerraformVersionConstraintFromJSON},
 	}
 

--- a/versionmanager/semantic/parser/terragrunt/gruntparser.go
+++ b/versionmanager/semantic/parser/terragrunt/gruntparser.go
@@ -35,8 +35,13 @@ import (
 )
 
 const (
-	HCLName  = "terragrunt.hcl"
-	JSONName = "terragrunt.hcl.json"
+	HCLName  = "root.hcl"
+	JSONName = "root.hcl.json"
+
+	// HCLNameLegacy is the legacy file name for the root Terragrunt HCL file.
+	HCLNameLegacy = "terragrunt.hcl"
+	// JSONNameLegacy is the legacy file name for the root Terragrunt JSON file.
+	JSONNameLegacy = "terragrunt.hcl.json"
 
 	terraformVersionConstraintName  = "terraform_version_constraint"
 	terragruntVersionConstraintName = "terragrunt_version_constraint"


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Context
When running plan/applies in newer versions of terragrunt, you now get the following output when the root configuration file is named `terragrunt.hcl`.

```
WARN[0000] Using `terragrunt.hcl` as the root of Terragrunt configurations is an anti-pattern, and no longer recommended. 
In a future version of Terragrunt, this will result in an error. You are advised to use a differently named file like `root.hcl` instead.
For more information, see https://terragrunt.gruntwork.io/docs/migrate/migrating-from-root-terragrunt-hcl
```

[Gruntwork now recommends](https://terragrunt.gruntwork.io/docs/migrate/migrating-from-root-terragrunt-hcl) renaming the root config file to `root.hcl` instead. This PR is to add support for the new recommended naming convention in versionmanager.

## Motivation
We've been doing some testing around using tenv to aid with Terraform & Terragrunt version management in our CI pipelines. Some repos use the new `root.hcl` format and tenv wasn't parsing `terraform_version_constraint` and 
`terragrunt_version_constraint` since the file was named differently.

I first thought of setting an env var to pass in a different root terragrunt file name instead to make this more customizable. However, most people will likely conform to rename the file using whatever GruntWorks recommends so I figured adding support for the most likely cases was the better approach. It makes using the tool even easier since out of the box it will work with the most common configurations.

## Summary of Change
The changes I made should be backwards compatible without changing anyone's current setup. 
The following was done:

1. I updated the consts in `gruntparser.go` with 2 new consts `HCLNameLegacy` and `JSONNameLegacy` and added some Go Doc compliant comments to indicate the move towards the new recommended naming convention.
1. Added in new VersionFile configs in the tf, tg, and tofu BuildManager functions to now include parsing of the root.hcl & root.hcl.json files in the returned VersionManager struct.
    -  I placed it after the terragrunt.hcl and terragrunt.hcl.json parser declarations to ensure this wouldn't break anyone's current setup using the legacy naming convention. So if they have both a terragrunt.hcl file and root.hcl file, the terragrunt.hcl file values will be the ones parsed and utilized.


## Testing
I built the binaries then tested out the logic to ensure that it is correctly parsing the legacy and newly named files. I also ensured that the legacy file name takes precedence over the new one.

Terraform Detect Tests
![image](https://github.com/user-attachments/assets/31204cf7-a6d5-4da6-87ce-e97c6a383995)

Terragrunt Detect Test
![tenv_testing_tg](https://github.com/user-attachments/assets/1ffce179-7dea-44f6-870e-c0b87afa2b16)

Tofu Detect Test
![tenv_testing_tofu](https://github.com/user-attachments/assets/ae07053a-8230-4150-9e9e-a65a7afd8179)

