### PR TITLE
Simplify goreleaser config for cloudsmith repos

### DIFF
--- a/.goreleaser_release_only.yml
+++ b/.goreleaser_release_only.yml
@@ -19,21 +19,18 @@ cloudsmiths:
   - organization: tofuutils
     repository: tenv
     distributions:
-      deb: "ubuntu/focal"
-      alpine: "alpine/v3.7"
-      rpm: "el/7"
-  - organization: tofuutils
-    repository: tenv
-    distributions:
-      deb: "ubuntu/jammy"
-      alpine: "alpine/v3.8"
-      rpm: "el/8"
-  - organization: tofuutils
-    repository: tenv
-    distributions:
-      deb: "ubuntu/noble"
-      alpine: "alpine/v3.9"
-      rpm: "el/9"
+      deb:
+        - "ubuntu/focal"
+        - "ubuntu/jammy"
+        - "ubuntu/noble"
+      alpine:
+        - "alpine/v3.7"
+        - "alpine/v3.8"
+        - "alpine/v3.9"
+      rpm:
+        - "el/7"
+        - "el/8"
+        - "el/9"
 
 aurs:
   - name: tenv-bin


### PR DESCRIPTION
Since version 2.8.0 goreleaser support simplified configuration for the cloudsmith repos. 