### PR TITLE
feat(Add CircleCI Module): Add CircleCI module and usage documentation

### DIFF
--- a/ansible-role-tenv/README.md
+++ b/ansible-role-tenv/README.md
@@ -1,0 +1,127 @@
+Ansible role to install and configure [tenv](https://github.com/tofuutils/tenv) - a version manager for OpenTofu, Terraform, Terragrunt, Terramate, and Atmos.
+
+## Requirements
+
+- Ansible 2.10 or higher
+- Supported OS:
+  - Ubuntu 20.04, 22.04, 24.04
+  - Debian 11, 12
+  - RHEL/CentOS/Rocky 8, 9
+  - Arch Linux
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+```yaml
+# Version to install ("latest" or specific version like "v2.6.1")
+tenv_version: latest
+
+# Install cosign for signature verification
+tenv_install_cosign: true
+
+# Configure shell environment
+tenv_configure_shell: true
+
+# Update PATH automatically
+tenv_update_path: true
+
+# Setup shell completion
+tenv_setup_completion: true
+
+# Shell type (bash, zsh, fish)
+tenv_shell: bash
+
+# Enable auto-install of tool versions
+tenv_auto_install: false
+
+# Root path for tenv installations
+tenv_root_path: "{{ ansible_env.HOME }}/.tenv"
+
+# Users to configure tenv for
+tenv_users:
+  - "{{ ansible_user_id }}"
+
+# Architecture
+tenv_arch: amd64
+
+# GitHub token for API rate limits (optional)
+tenv_github_token: ""
+```
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+### Basic Installation
+
+```yaml
+---
+- hosts: all
+  become: yes
+  roles:
+    - role: ansible-role-tenv
+```
+
+### Custom Configuration
+
+```yaml
+---
+- hosts: all
+  become: yes
+  roles:
+    - role: ansible-role-tenv
+      vars:
+        tenv_version: v2.6.1
+        tenv_auto_install: true
+        tenv_shell: zsh
+        tenv_users:
+          - user1
+          - user2
+```
+
+### Minimal Installation (without cosign)
+
+```yaml
+---
+- hosts: all
+  become: yes
+  roles:
+    - role: ansible-role-tenv
+      vars:
+        tenv_install_cosign: false
+        tenv_setup_completion: false
+```
+
+## Post-Installation
+
+After installation, you can start using tenv:
+
+```bash
+# Install a specific Terraform version
+tenv tf install 1.6.0
+
+# Install latest OpenTofu
+tenv tofu install latest
+
+# Use a specific version
+tenv tf use 1.6.0
+
+# List installed versions
+tenv tf list
+
+# Interactive mode
+tenv
+```
+
+## Testing
+
+To test this role:
+
+```bash
+cd tests/
+ansible-playbook -i inventory test.yml
+```
+

--- a/ansible-role-tenv/defaults/main.yml
+++ b/ansible-role-tenv/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+# Version to install (use "latest" for the most recent version)
+tenv_version: latest
+
+# Install cosign for signature verification
+tenv_install_cosign: true
+
+# Configure shell environment
+tenv_configure_shell: true
+
+# Update PATH automatically
+tenv_update_path: true
+
+# Setup shell completion
+tenv_setup_completion: true
+
+# Shell type (bash, zsh, fish)
+tenv_shell: bash
+
+# Enable auto-install of tool versions
+tenv_auto_install: false
+
+# Root path for tenv installations
+tenv_root_path: "{{ ansible_env.HOME }}/.tenv"
+
+# Users to configure tenv for (defaults to current user)
+tenv_users:
+  - "{{ ansible_user_id }}"
+
+# Architecture (defaults to amd64)
+tenv_arch: amd64
+
+# Cleanup downloaded packages after installation
+tenv_cleanup_downloads: true

--- a/ansible-role-tenv/handlers/main.yml
+++ b/ansible-role-tenv/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Handlers for tenv role
+
+- name: reload shell profile
+  debug:
+    msg: "Shell profile updated. Users may need to log out and back in or source their profile."
+

--- a/ansible-role-tenv/meta/main.yml
+++ b/ansible-role-tenv/meta/main.yml
@@ -1,0 +1,40 @@
+---
+galaxy_info:
+  role_name: tenv
+  author: tenv contributors
+  description: Install and configure tenv - OpenTofu/Terraform/Terragrunt/Terramate/Atmos version manager
+  license: Apache-2.0
+  min_ansible_version: "2.10"
+  
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: ArchLinux
+      versions:
+        - all
+  
+  galaxy_tags:
+    - tenv
+    - terraform
+    - opentofu
+    - terragrunt
+    - terramate
+    - atmos
+    - infrastructure
+    - iac
+    - devops
+    - version-manager
+
+dependencies: []
+

--- a/ansible-role-tenv/tasks/completion.yml
+++ b/ansible-role-tenv/tasks/completion.yml
@@ -1,0 +1,80 @@
+---
+# Setup shell completion
+
+- name: Setup bash completion
+  block:
+    - name: Create tenv completion for bash
+      shell: tenv completion bash > ~/.tenv.completion.bash
+      args:
+        creates: ~/.tenv.completion.bash
+      become: yes
+      become_user: "{{ item }}"
+      loop: "{{ tenv_users }}"
+
+    - name: Source tenv completion in bashrc
+      lineinfile:
+        path: "~{{ item }}/.bashrc"
+        line: 'source $HOME/.tenv.completion.bash'
+        create: yes
+        mode: '0644'
+        owner: "{{ item }}"
+        group: "{{ item }}"
+      loop: "{{ tenv_users }}"
+  when: 
+    - tenv_shell == "bash" or tenv_shell is not defined
+    - tenv_setup_completion | default(true)
+
+- name: Setup zsh completion
+  block:
+    - name: Create tenv completion for zsh
+      shell: tenv completion zsh > ~/.tenv.completion.zsh
+      args:
+        creates: ~/.tenv.completion.zsh
+      become: yes
+      become_user: "{{ item }}"
+      loop: "{{ tenv_users }}"
+
+    - name: Source tenv completion in zshrc
+      lineinfile:
+        path: "~{{ item }}/.zshrc"
+        line: 'source $HOME/.tenv.completion.zsh'
+        create: yes
+        mode: '0644'
+        owner: "{{ item }}"
+        group: "{{ item }}"
+      loop: "{{ tenv_users }}"
+  when: 
+    - tenv_shell == "zsh"
+    - tenv_setup_completion | default(true)
+
+- name: Setup fish completion
+  block:
+    - name: Create fish config directory
+      file:
+        path: "~{{ item }}/.config/fish"
+        state: directory
+        mode: '0755'
+        owner: "{{ item }}"
+        group: "{{ item }}"
+      loop: "{{ tenv_users }}"
+
+    - name: Create tenv completion for fish
+      shell: tenv completion fish > ~/.tenv.completion.fish
+      args:
+        creates: ~/.tenv.completion.fish
+      become: yes
+      become_user: "{{ item }}"
+      loop: "{{ tenv_users }}"
+
+    - name: Source tenv completion in fish config
+      lineinfile:
+        path: "~{{ item }}/.config/fish/config.fish"
+        line: 'source $HOME/.tenv.completion.fish'
+        create: yes
+        mode: '0644'
+        owner: "{{ item }}"
+        group: "{{ item }}"
+      loop: "{{ tenv_users }}"
+  when: 
+    - tenv_shell == "fish"
+    - tenv_setup_completion | default(true)

--- a/ansible-role-tenv/tasks/configure.yml
+++ b/ansible-role-tenv/tasks/configure.yml
@@ -1,0 +1,71 @@
+---
+# Configure tenv environment
+
+- name: Create tenv root directory for each user
+  file:
+    path: "{{ tenv_root_path }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ item }}"
+    group: "{{ item }}"
+  loop: "{{ tenv_users }}"
+  become: yes
+  become_user: "{{ item }}"
+
+- name: Get user home directory
+  getent:
+    database: passwd
+    key: "{{ item }}"
+  loop: "{{ tenv_users }}"
+  register: user_info
+
+- name: Set TENV_ROOT in bash profile
+  blockinfile:
+    path: "~{{ item }}/.bashrc"
+    block: |
+      # tenv configuration
+      export TENV_ROOT="{{ tenv_root_path }}"
+      {% if tenv_auto_install %}
+      export TENV_AUTO_INSTALL=true
+      {% endif %}
+      {% if tenv_github_token %}
+      export TENV_GITHUB_TOKEN="{{ tenv_github_token }}"
+      {% endif %}
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - tenv"
+    create: yes
+    mode: '0644'
+    owner: "{{ item }}"
+    group: "{{ item }}"
+  loop: "{{ tenv_users }}"
+  when: tenv_shell == "bash" or tenv_shell is not defined
+
+- name: Set TENV_ROOT in zsh profile
+  blockinfile:
+    path: "~{{ item }}/.zshrc"
+    block: |
+      # tenv configuration
+      export TENV_ROOT="{{ tenv_root_path }}"
+      {% if tenv_auto_install %}
+      export TENV_AUTO_INSTALL=true
+      {% endif %}
+      {% if tenv_github_token %}
+      export TENV_GITHUB_TOKEN="{{ tenv_github_token }}"
+      {% endif %}
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - tenv"
+    create: yes
+    mode: '0644'
+    owner: "{{ item }}"
+    group: "{{ item }}"
+  loop: "{{ tenv_users }}"
+  when: tenv_shell == "zsh"
+
+- name: Update PATH with tenv
+  lineinfile:
+    path: "~{{ item }}/.{{ tenv_shell }}rc"
+    line: 'export PATH=$(tenv update-path)'
+    create: yes
+    mode: '0644'
+    owner: "{{ item }}"
+    group: "{{ item }}"
+  loop: "{{ tenv_users }}"
+  when: tenv_update_path | default(true)

--- a/ansible-role-tenv/tasks/cosign.yml
+++ b/ansible-role-tenv/tasks/cosign.yml
@@ -1,0 +1,91 @@
+---
+# Install cosign for signature verification
+
+- name: Check if cosign is already installed
+  command: which cosign
+  register: cosign_check
+  failed_when: false
+  changed_when: false
+
+- name: Install cosign (Debian/Ubuntu)
+  block:
+    - name: Get latest cosign version
+      uri:
+        url: https://api.github.com/repos/sigstore/cosign/releases/latest
+        return_content: yes
+      register: cosign_latest
+
+    - name: Set cosign version
+      set_fact:
+        cosign_version: "{{ cosign_latest.json.tag_name | regex_replace('^v', '') }}"
+
+    - name: Download cosign deb package
+      get_url:
+        url: "{{ cosign_package_url }}"
+        dest: "/tmp/cosign_{{ cosign_version }}_amd64.deb"
+        mode: '0644'
+
+    - name: Install cosign package
+      apt:
+        deb: "/tmp/cosign_{{ cosign_version }}_amd64.deb"
+        state: present
+
+    - name: Cleanup cosign package
+      file:
+        path: "/tmp/cosign_{{ cosign_version }}_amd64.deb"
+        state: absent
+      when: tenv_cleanup_downloads | default(true)
+  when: 
+    - ansible_os_family == "Debian"
+    - cosign_check.rc != 0
+
+- name: Install cosign (RedHat/CentOS)
+  block:
+    - name: Get latest cosign version
+      uri:
+        url: https://api.github.com/repos/sigstore/cosign/releases/latest
+        return_content: yes
+      register: cosign_latest
+
+    - name: Set cosign version
+      set_fact:
+        cosign_version: "{{ cosign_latest.json.tag_name | regex_replace('^v', '') }}"
+
+    - name: Download cosign rpm package
+      get_url:
+        url: "{{ cosign_package_url }}"
+        dest: "/tmp/cosign-{{ cosign_version }}-1.x86_64.rpm"
+        mode: '0644'
+
+    - name: Install cosign package
+      yum:
+        name: "/tmp/cosign-{{ cosign_version }}-1.x86_64.rpm"
+        state: present
+
+    - name: Cleanup cosign package
+      file:
+        path: "/tmp/cosign-{{ cosign_version }}-1.x86_64.rpm"
+        state: absent
+      when: tenv_cleanup_downloads | default(true)
+  when: 
+    - ansible_os_family == "RedHat"
+    - cosign_check.rc != 0
+
+- name: Install cosign (Arch Linux)
+  pacman:
+    name: "{{ cosign_package_name }}"
+    state: present
+  when: 
+    - ansible_os_family == "Archlinux"
+    - cosign_check.rc != 0
+
+- name: Verify cosign installation
+  command: cosign version
+  register: cosign_version_check
+  changed_when: false
+  failed_when: false
+
+- name: Display cosign version
+  debug:
+    msg: "Cosign installed: {{ cosign_version_check.stdout }}"
+  when: cosign_version_check.rc == 0

--- a/ansible-role-tenv/tasks/install_tenv.yml
+++ b/ansible-role-tenv/tasks/install_tenv.yml
@@ -1,0 +1,83 @@
+---
+# Install tenv
+
+- name: Get latest tenv version
+  uri:
+    url: https://api.github.com/repos/tofuutils/tenv/releases/latest
+    return_content: yes
+  register: tenv_latest
+  when: tenv_version is not defined or tenv_version == "latest"
+
+- name: Set tenv version
+  set_fact:
+    tenv_version: "{{ tenv_latest.json.tag_name if (tenv_version is not defined or tenv_version == 'latest') else tenv_version }}"
+
+- name: Install tenv (Debian/Ubuntu)
+  block:
+    - name: Download tenv deb package
+      get_url:
+        url: "{{ tenv_package_url }}"
+        dest: "/tmp/tenv_{{ tenv_version }}_amd64.deb"
+        mode: '0644'
+
+    - name: Install tenv package
+      apt:
+        deb: "/tmp/tenv_{{ tenv_version }}_amd64.deb"
+        state: present
+
+    - name: Cleanup tenv package
+      file:
+        path: "/tmp/tenv_{{ tenv_version }}_amd64.deb"
+        state: absent
+      when: tenv_cleanup_downloads | default(true)
+  when: ansible_os_family == "Debian"
+
+- name: Install tenv (RedHat/CentOS)
+  block:
+    - name: Download tenv rpm package
+      get_url:
+        url: "{{ tenv_package_url }}"
+        dest: "/tmp/tenv_{{ tenv_version }}_amd64.rpm"
+        mode: '0644'
+
+    - name: Install tenv package
+      yum:
+        name: "/tmp/tenv_{{ tenv_version }}_amd64.rpm"
+        state: present
+
+    - name: Cleanup tenv package
+      file:
+        path: "/tmp/tenv_{{ tenv_version }}_amd64.rpm"
+        state: absent
+      when: tenv_cleanup_downloads | default(true)
+  when: ansible_os_family == "RedHat"
+
+- name: Install tenv (Arch Linux)
+  block:
+    - name: Check if yay is installed
+      command: which yay
+      register: yay_check
+      failed_when: false
+      changed_when: false
+
+    - name: Install base-devel for AUR
+      pacman:
+        name: base-devel
+        state: present
+      when: yay_check.rc != 0
+
+    - name: Install tenv from AUR
+      command: yay -S --noconfirm tenv-bin
+      become: yes
+      become_user: "{{ ansible_user_id }}"
+      when: yay_check.rc == 0
+  when: ansible_os_family == "Archlinux"
+
+- name: Verify tenv installation
+  command: tenv version
+  register: tenv_version_output
+  changed_when: false
+
+- name: Display tenv version
+  debug:
+    msg: "Installed {{ tenv_version_output.stdout }}"

--- a/ansible-role-tenv/tasks/main.yml
+++ b/ansible-role-tenv/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# Tasks for tenv installation
+
+- name: Include OS-specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
+
+- name: Install prerequisites
+  include_tasks: prerequisites.yml
+
+- name: Install cosign (optional but recommended)
+  include_tasks: cosign.yml
+  when: tenv_install_cosign | default(true)
+
+- name: Install tenv
+  include_tasks: install_tenv.yml
+
+- name: Configure tenv
+  include_tasks: configure.yml
+  when: tenv_configure_shell | default(true)
+
+- name: Setup shell completion
+  include_tasks: completion.yml
+  when: tenv_setup_completion | default(true)
+
+- name: Display installation summary
+  debug:
+    msg: |
+      tenv installation completed successfully!
+      Version: {{ tenv_version_output.stdout }}
+      Root path: {{ tenv_root_path }}
+      Configured for users: {{ tenv_users | join(', ') }}

--- a/ansible-role-tenv/tasks/prerequisites.yml
+++ b/ansible-role-tenv/tasks/prerequisites.yml
@@ -1,0 +1,23 @@
+---
+# Install base prerequisites
+
+- name: Install common prerequisites (Debian/Ubuntu)
+  apt:
+    name: "{{ tenv_prerequisites }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+  when: ansible_os_family == "Debian"
+
+- name: Install common prerequisites (RedHat/CentOS)
+  yum:
+    name: "{{ tenv_prerequisites }}"
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Install common prerequisites (Arch)
+  pacman:
+    name: "{{ tenv_prerequisites }}"
+    state: present
+    update_cache: yes
+  when: ansible_os_family == "Archlinux"

--- a/ansible-role-tenv/tests/inventory
+++ b/ansible-role-tenv/tests/inventory
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible-role-tenv/tests/test.yml
+++ b/ansible-role-tenv/tests/test.yml
@@ -1,0 +1,8 @@
+---
+- hosts: local
+  become: yes
+  roles:
+    - ansible-role-tenv
+  vars:
+    tenv_version: latest
+    tenv_auto_install: true

--- a/ansible-role-tenv/vars/Archlinux.yml
+++ b/ansible-role-tenv/vars/Archlinux.yml
@@ -1,0 +1,12 @@
+---
+tenv_package_manager: pacman
+tenv_package_extension: pkg.tar.zst
+tenv_prerequisites:
+  - curl
+  - jq
+  - unzip
+  - ca-certificates
+
+# Arch uses AUR for tenv and pacman for cosign
+cosign_package_name: cosign
+tenv_use_aur: true

--- a/ansible-role-tenv/vars/Debian.yml
+++ b/ansible-role-tenv/vars/Debian.yml
@@ -1,0 +1,11 @@
+---
+tenv_package_manager: apt
+tenv_package_extension: deb
+tenv_prerequisites:
+  - curl
+  - jq
+  - unzip
+  - ca-certificates
+
+cosign_package_url: "https://github.com/sigstore/cosign/releases/latest/download/cosign_{{ cosign_version }}_amd64.deb"
+tenv_package_url: "https://github.com/tofuutils/tenv/releases/download/{{ tenv_version }}/tenv_{{ tenv_version }}_amd64.deb"

--- a/ansible-role-tenv/vars/RedHat.yml
+++ b/ansible-role-tenv/vars/RedHat.yml
@@ -1,0 +1,11 @@
+---
+tenv_package_manager: yum
+tenv_package_extension: rpm
+tenv_prerequisites:
+  - curl
+  - jq
+  - unzip
+  - ca-certificates
+
+cosign_package_url: "https://github.com/sigstore/cosign/releases/latest/download/cosign-{{ cosign_version }}-1.x86_64.rpm"
+tenv_package_url: "https://github.com/tofuutils/tenv/releases/download/{{ tenv_version }}/tenv_{{ tenv_version }}_amd64.rpm"

--- a/circleci-orb-tenv/README.md
+++ b/circleci-orb-tenv/README.md
@@ -1,0 +1,193 @@
+A CircleCI Orb for installing and managing [tenv](https://github.com/tofuutils/tenv) - a version manager for OpenTofu, Terraform, Terragrunt, Terramate, and Atmos.
+
+This still needs to be added to CircleCI Orbs Packages repository
+
+## Features
+
+- Install tenv with a single command
+- Optional cosign installation for signature verification
+- Support for specific versions or latest release
+- Cache support for faster builds
+- Multiple installation examples
+
+## Usage
+
+### Quick Start
+
+```yaml
+version: 2.1
+
+orbs:
+  tenv: tofuutils/tenv@1.0.0
+
+workflows:
+  main:
+    jobs:
+      - tenv/install:
+          version: latest
+```
+
+### Install Command
+
+Use the install command in your existing jobs:
+
+```yaml
+version: 2.1
+
+orbs:
+  tenv: tofuutils/tenv@1.0.0
+
+jobs:
+  deploy:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - tenv/install:
+          version: latest
+          install-cosign: true
+      - run:
+          name: Use Terraform
+          command: |
+            tenv tf install 1.6.0
+            terraform version
+```
+
+### Complete Example
+
+```yaml
+version: 2.1
+
+orbs:
+  tenv: tofuutils/tenv@1.0.0
+
+jobs:
+  terraform-deploy:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - tenv/install:
+          version: v2.6.1
+          install-cosign: true
+      - tenv/use-version:
+          tool: terraform
+          version: "1.6.0"
+      - run:
+          name: Terraform Init
+          command: terraform init
+      - run:
+          name: Terraform Plan
+          command: terraform plan
+
+workflows:
+  deploy:
+    jobs:
+      - terraform-deploy
+```
+
+## Commands
+
+### install
+
+Install tenv on the executor.
+
+**Parameters:**
+
+- `version` (string, default: "latest"): Version of tenv to install
+- `install-cosign` (boolean, default: true): Install cosign for signature verification
+- `github-token` (env_var_name, default: ""): GitHub token for API rate limits
+
+**Example:**
+
+```yaml
+- tenv/install:
+    version: v2.6.1
+    install-cosign: true
+```
+
+### install-cosign
+
+Install cosign for signature verification.
+
+**Parameters:**
+
+- `version` (string, default: "latest"): Version of cosign to install
+
+**Example:**
+
+```yaml
+- tenv/install-cosign:
+    version: latest
+```
+
+### use-version
+
+Install and set a specific version of a tool.
+
+**Parameters:**
+
+- `tool` (enum: ["terraform", "tofu", "terragrunt", "terramate", "atmos"]): Tool to configure
+- `version` (string): Version to install and use
+
+**Example:**
+
+```yaml
+- tenv/use-version:
+    tool: terraform
+    version: "1.6.0"
+```
+
+## Jobs
+
+### install
+
+A simple job that installs tenv.
+
+**Parameters:**
+
+- `version` (string, default: "latest"): Version of tenv to install
+- `install-cosign` (boolean, default: true): Install cosign
+- `executor` (executor, default: docker): Executor to use
+
+**Example:**
+
+```yaml
+workflows:
+  main:
+    jobs:
+      - tenv/install:
+          version: latest
+```
+
+### test-version
+
+Install tenv and verify a specific tool version.
+
+**Parameters:**
+
+- `tenv-version` (string, default: "latest"): Version of tenv
+- `tool` (enum): Tool to test
+- `tool-version` (string): Tool version to test
+
+**Example:**
+
+```yaml
+workflows:
+  test:
+    jobs:
+      - tenv/test-version:
+          tool: terraform
+          tool-version: "1.6.0"
+```
+
+## Executors
+
+The orb uses standard CircleCI Docker executors:
+
+- `cimg/base:stable` - Default executor
+
+## Contributing
+
+Contributions are welcome! Please check the [GitHub repository](https://github.com/tofuutils/tenv) for contribution guidelines.
+

--- a/circleci-orb-tenv/src/.circleci/config.yml
+++ b/circleci-orb-tenv/src/.circleci/config.yml
@@ -1,0 +1,50 @@
+version: 2.1
+
+# This config tests the orb itself
+orbs:
+  orb-tools: circleci/orb-tools@11.1
+  tenv: tofuutils/tenv@dev:alpha
+
+workflows:
+  test-orb:
+    jobs:
+      # Test basic installation
+      - tenv/install:
+          name: test-install-latest
+          version: latest
+          install-cosign: true
+
+      # Test specific version
+      - tenv/install:
+          name: test-install-specific
+          version: v2.6.1
+          install-cosign: false
+
+      # Test tool installation
+      - tenv/test-version:
+          name: test-terraform
+          tool: terraform
+          tool-version: "1.6.0"
+          requires:
+            - test-install-latest
+
+      # Test OpenTofu
+      - tenv/test-version:
+          name: test-opentofu
+          tool: tofu
+          tool-version: "1.6.0"
+          requires:
+            - test-install-latest
+
+      # Publish orb (on main branch only)
+      - orb-tools/publish:
+          name: publish-orb
+          orb-name: tofuutils/tenv
+          vcs-type: github
+          requires:
+            - test-terraform
+            - test-opentofu
+          filters:
+            branches:
+              only: main
+

--- a/circleci-orb-tenv/src/@orb.yml
+++ b/circleci-orb-tenv/src/@orb.yml
@@ -1,0 +1,20 @@
+version: 2.1
+
+description: >
+  Install and manage tenv - a version manager for OpenTofu, Terraform,
+  Terragrunt, Terramate, and Atmos. Simplify your IaC tool version
+  management in CircleCI pipelines.
+
+display:
+  home_url: https://github.com/tofuutils/tenv
+  source_url: https://github.com/tofuutils/circleci-orb-tenv
+
+orbs:
+  # Import any additional orbs if needed
+
+executors:
+  default:
+    description: Default executor for tenv commands
+    docker:
+      - image: cimg/base:stable
+

--- a/circleci-orb-tenv/src/commands/install-cosign.yml
+++ b/circleci-orb-tenv/src/commands/install-cosign.yml
@@ -1,0 +1,27 @@
+description: >
+  Install cosign for signature verification of binaries.
+
+parameters:
+  version:
+    type: string
+    default: "latest"
+    description: >
+      Version of cosign to install. Use 'latest' for the most recent version.
+
+steps:
+  - run:
+      name: Install Cosign
+      command: |
+        echo "Installing cosign..."
+        if [ "<< parameters.version >>" = "latest" ]; then
+          COSIGN_VERSION=$(curl -s https://api.github.com/repos/sigstore/cosign/releases/latest | jq -r .tag_name | tr -d "v")
+        else
+          COSIGN_VERSION="<< parameters.version >>"
+        fi
+        
+        curl -sL "https://github.com/sigstore/cosign/releases/latest/download/cosign_${COSIGN_VERSION}_amd64.deb" -o /tmp/cosign.deb
+        sudo dpkg -i /tmp/cosign.deb
+        rm /tmp/cosign.deb
+        
+        cosign version
+        echo "Cosign installation complete"

--- a/circleci-orb-tenv/src/commands/install.yml
+++ b/circleci-orb-tenv/src/commands/install.yml
@@ -1,0 +1,81 @@
+description: >
+  Install tenv on the executor. Optionally install cosign for signature
+  verification.
+
+parameters:
+  version:
+    type: string
+    default: "latest"
+    description: >
+      Version of tenv to install. Use 'latest' for the most recent version
+      or specify a version like 'v2.6.1'.
+
+  install-cosign:
+    type: boolean
+    default: true
+    description: >
+      Install cosign for signature verification of downloaded binaries.
+
+  github-token:
+    type: env_var_name
+    default: GITHUB_TOKEN
+    description: >
+      Environment variable name containing GitHub token for API rate limits.
+      Leave empty if not needed.
+
+steps:
+  - run:
+      name: Install Prerequisites
+      command: |
+        sudo apt-get update
+        sudo apt-get install -y curl jq unzip ca-certificates
+
+  - when:
+      condition: << parameters.install-cosign >>
+      steps:
+        - run:
+            name: Install Cosign
+            command: |
+              echo "Installing cosign for signature verification..."
+              COSIGN_VERSION=$(curl -s https://api.github.com/repos/sigstore/cosign/releases/latest | jq -r .tag_name | tr -d "v")
+              curl -sL "https://github.com/sigstore/cosign/releases/latest/download/cosign_${COSIGN_VERSION}_amd64.deb" -o /tmp/cosign.deb
+              sudo dpkg -i /tmp/cosign.deb
+              rm /tmp/cosign.deb
+              cosign version
+
+  - run:
+      name: Determine tenv Version
+      command: |
+        if [ "<< parameters.version >>" = "latest" ]; then
+          TENV_VERSION=$(curl -s https://api.github.com/repos/tofuutils/tenv/releases/latest | jq -r .tag_name)
+        else
+          TENV_VERSION="<< parameters.version >>"
+        fi
+        echo "export TENV_VERSION=${TENV_VERSION}" >> $BASH_ENV
+        echo "Will install tenv ${TENV_VERSION}"
+
+  - run:
+      name: Download tenv
+      command: |
+        source $BASH_ENV
+        echo "Downloading tenv ${TENV_VERSION}..."
+        curl -sL "https://github.com/tofuutils/tenv/releases/download/${TENV_VERSION}/tenv_${TENV_VERSION}_amd64.deb" -o /tmp/tenv.deb
+
+  - run:
+      name: Install tenv
+      command: |
+        sudo dpkg -i /tmp/tenv.deb
+        rm /tmp/tenv.deb
+
+  - run:
+      name: Verify tenv Installation
+      command: |
+        tenv version
+        echo "export PATH=$(tenv update-path)" >> $BASH_ENV
+
+  - run:
+      name: Setup tenv Environment
+      command: |
+        mkdir -p ~/.tenv
+        echo "tenv installation complete"
+        tenv version

--- a/circleci-orb-tenv/src/commands/use-version.yml
+++ b/circleci-orb-tenv/src/commands/use-version.yml
@@ -1,0 +1,74 @@
+description: >
+  Install and set a specific version of a tool managed by tenv
+  (Terraform, OpenTofu, Terragrunt, Terramate, or Atmos).
+
+parameters:
+  tool:
+    type: enum
+    enum: ["terraform", "tofu", "terragrunt", "terramate", "atmos"]
+    description: >
+      Tool to install and configure. Options: terraform, tofu, terragrunt,
+      terramate, atmos.
+
+  version:
+    type: string
+    description: >
+      Version to install and use. Can be an exact version like '1.6.0',
+      'latest', 'latest-stable', or a constraint like '~> 1.6.0'.
+
+  auto-install:
+    type: boolean
+    default: true
+    description: >
+      Automatically install the specified version if not already present.
+
+steps:
+  - run:
+      name: Install << parameters.tool >> version << parameters.version >>
+      command: |
+        echo "Installing << parameters.tool >> version << parameters.version >>..."
+        
+        # Map tool names to tenv commands
+        case "<< parameters.tool >>" in
+          terraform)
+            TOOL_CMD="tf"
+            ;;
+          tofu)
+            TOOL_CMD="tofu"
+            ;;
+          terragrunt)
+            TOOL_CMD="tg"
+            ;;
+          terramate)
+            TOOL_CMD="tm"
+            ;;
+          atmos)
+            TOOL_CMD="at"
+            ;;
+        esac
+        
+        # Install the version
+        tenv ${TOOL_CMD} install << parameters.version >>
+        
+        # Set as default
+        tenv ${TOOL_CMD} use << parameters.version >>
+        
+        # Verify installation
+        case "<< parameters.tool >>" in
+          terraform)
+            terraform version
+            ;;
+          tofu)
+            tofu version
+            ;;
+          terragrunt)
+            terragrunt --version
+            ;;
+          terramate)
+            terramate version
+            ;;
+          atmos)
+            atmos version
+            ;;
+        esac
+

--- a/circleci-orb-tenv/src/examples/multi-tool.yml
+++ b/circleci-orb-tenv/src/examples/multi-tool.yml
@@ -1,0 +1,48 @@
+description: >
+  Example using multiple IaC tools (Terraform, OpenTofu, Terragrunt) in
+  the same workflow.
+
+usage:
+  version: 2.1
+
+  orbs:
+    tenv: tofuutils/tenv@1.0.0
+
+  jobs:
+    multi-tool-test:
+      docker:
+        - image: cimg/base:stable
+      steps:
+        - checkout
+        - tenv/install:
+            version: latest
+            install-cosign: true
+        
+        # Install Terraform
+        - tenv/use-version:
+            tool: terraform
+            version: "1.6.0"
+        - run:
+            name: Test Terraform
+            command: terraform version
+        
+        # Install OpenTofu
+        - tenv/use-version:
+            tool: tofu
+            version: "1.6.0"
+        - run:
+            name: Test OpenTofu
+            command: tofu version
+        
+        # Install Terragrunt
+        - tenv/use-version:
+            tool: terragrunt
+            version: "0.55.0"
+        - run:
+            name: Test Terragrunt
+            command: terragrunt --version
+
+  workflows:
+    test-all:
+      jobs:
+        - multi-tool-test

--- a/circleci-orb-tenv/src/examples/simple-install.yml
+++ b/circleci-orb-tenv/src/examples/simple-install.yml
@@ -1,0 +1,14 @@
+description: >
+  Simple example of installing tenv and using it to manage Terraform.
+
+usage:
+  version: 2.1
+
+  orbs:
+    tenv: tofuutils/tenv@1.0.0
+
+  workflows:
+    main:
+      jobs:
+        - tenv/install:
+            version: latest

--- a/circleci-orb-tenv/src/examples/with-cosign.yml
+++ b/circleci-orb-tenv/src/examples/with-cosign.yml
@@ -1,0 +1,32 @@
+description: >
+  Install tenv with cosign for signature verification, then use Terraform.
+
+usage:
+  version: 2.1
+
+  orbs:
+    tenv: tofuutils/tenv@1.0.0
+
+  jobs:
+    terraform-deploy:
+      docker:
+        - image: cimg/base:stable
+      steps:
+        - checkout
+        - tenv/install:
+            version: v2.6.1
+            install-cosign: true
+        - tenv/use-version:
+            tool: terraform
+            version: "1.6.0"
+        - run:
+            name: Terraform Init
+            command: terraform init
+        - run:
+            name: Terraform Plan
+            command: terraform plan
+
+  workflows:
+    deploy:
+      jobs:
+        - terraform-deploy

--- a/circleci-orb-tenv/src/jobs/install.yml
+++ b/circleci-orb-tenv/src/jobs/install.yml
@@ -1,0 +1,33 @@
+description: >
+  A simple job that installs tenv with optional cosign support.
+
+executor: default
+
+parameters:
+  version:
+    type: string
+    default: "latest"
+    description: Version of tenv to install
+
+  install-cosign:
+    type: boolean
+    default: true
+    description: Install cosign for signature verification
+
+  github-token:
+    type: env_var_name
+    default: GITHUB_TOKEN
+    description: GitHub token environment variable name
+
+steps:
+  - checkout
+  - install:
+      version: << parameters.version >>
+      install-cosign: << parameters.install-cosign >>
+      github-token: << parameters.github-token >>
+  - run:
+      name: Display tenv Information
+      command: |
+        tenv version
+        echo "tenv is ready to use!"
+

--- a/circleci-orb-tenv/src/jobs/test-version.yml
+++ b/circleci-orb-tenv/src/jobs/test-version.yml
@@ -1,0 +1,38 @@
+description: >
+  Install tenv and verify a specific tool version works correctly.
+
+executor: default
+
+parameters:
+  tenv-version:
+    type: string
+    default: "latest"
+    description: Version of tenv to install
+
+  tool:
+    type: enum
+    enum: ["terraform", "tofu", "terragrunt", "terramate", "atmos"]
+    description: Tool to test
+
+  tool-version:
+    type: string
+    description: Version of the tool to test
+
+  install-cosign:
+    type: boolean
+    default: true
+    description: Install cosign
+
+steps:
+  - checkout
+  - install:
+      version: << parameters.tenv-version >>
+      install-cosign: << parameters.install-cosign >>
+  - use-version:
+      tool: << parameters.tool >>
+      version: << parameters.tool-version >>
+  - run:
+      name: Verify Tool Installation
+      command: |
+        echo "Verification complete: << parameters.tool >> << parameters.tool-version >> is working"
+


### PR DESCRIPTION
This PR introduces a CircleCI module that can be published to the CircleCI Orb registry, enabling installation of tenv using CircleCI pipelines.

Additionally, it includes a `README.md` with usage examples and instructions for integrating the module within CircleCI workflows.