### PR TITLE
Add configurable lock file path support for filesystem compatibility

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -96,13 +96,15 @@ func DefaultConfig() (Config, error) {
 		return Config{}, err
 	}
 
+	tenvPath := filepath.Join(userPath, defaultDirName)
+
 	return Config{
 		Arch:             runtime.GOARCH,
 		Atmos:            makeDefaultRemoteConfig(atmosurl.Github, githuburl.Base),
 		Getenv:           EmptyGetenv,
-		LockPath:         filepath.Join(userPath, defaultDirName),
+		LockPath:         tenvPath,
 		remoteConfLoaded: true,
-		RootPath:         filepath.Join(userPath, defaultDirName),
+		RootPath:         tenvPath,
 		SkipInstall:      true,
 		Tf:               makeDefaultRemoteConfig(terraformurl.Hashicorp, terraformurl.Hashicorp),
 		Tg:               makeDefaultRemoteConfig(terragrunturl.Github, githuburl.Base),
@@ -144,7 +146,7 @@ func InitConfigFromEnv() (Config, error) {
 		rootPath = filepath.Join(userPath, defaultDirName)
 	}
 
-	lockPath := getenv.Fallback(envname.TenvLockPath, envname.TofuRootPath, envname.TfRootPath)
+	lockPath := getenv(envname.TenvLockPath)
 	if lockPath == "" {
 		lockPath = rootPath // Default to root path for backward compatibility
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	Getenv           configutils.GetenvFunc
 	GithubActions    bool
 	GithubToken      string
+	LockPath         string
 	remoteConfLoaded bool
 	RemoteConfPath   string
 	RootPath         string
@@ -99,6 +100,7 @@ func DefaultConfig() (Config, error) {
 		Arch:             runtime.GOARCH,
 		Atmos:            makeDefaultRemoteConfig(atmosurl.Github, githuburl.Base),
 		Getenv:           EmptyGetenv,
+		LockPath:         filepath.Join(userPath, defaultDirName),
 		remoteConfLoaded: true,
 		RootPath:         filepath.Join(userPath, defaultDirName),
 		SkipInstall:      true,
@@ -142,6 +144,11 @@ func InitConfigFromEnv() (Config, error) {
 		rootPath = filepath.Join(userPath, defaultDirName)
 	}
 
+	lockPath := getenv.Fallback(envname.TenvLockPath, envname.TofuRootPath, envname.TfRootPath)
+	if lockPath == "" {
+		lockPath = rootPath // Default to root path for backward compatibility
+	}
+
 	quiet, err := getenv.Bool(false, envname.TenvQuiet)
 	if err != nil {
 		return Config{}, err
@@ -155,6 +162,7 @@ func InitConfigFromEnv() (Config, error) {
 		Getenv:           getenv,
 		GithubActions:    getenv.Present(envname.GithubActions),
 		GithubToken:      getenv.Fallback(envname.TenvToken, envname.TofuToken),
+		LockPath:         lockPath,
 		RemoteConfPath:   getenv(envname.TenvRemoteConf),
 		RootPath:         rootPath,
 		SkipInstall:      !autoInstall,

--- a/config/envname/env.go
+++ b/config/envname/env.go
@@ -57,6 +57,7 @@ const (
 	TenvQuiet       = tenvPrefix + quiet
 	TenvRemoteConf  = tenvPrefix + "REMOTE_CONF"
 	TenvRootPath    = tenvPrefix + rootPath
+	TenvLockPath    = tenvPrefix + "LOCK_PATH"
 	TenvSkipLastUse = tenvPrefix + "SKIP_LAST_USE"
 	TenvToken       = tenvPrefix + token
 	TenvValidation  = tenvPrefix + "VALIDATION"

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -40,9 +40,15 @@ const (
 // ! dirPath must already exist (no mkdir here).
 // the returned function must be used to delete the lock.
 func Write(dirPath string, displayer loghelper.Displayer) func() {
-	lockPath := filepath.Join(dirPath, ".lock")
+	return WriteWithCustomLockPath(dirPath, filepath.Join(dirPath, ".lock"), displayer)
+}
+
+// WriteWithCustomLockPath allows specifying a custom lock file path.
+// ! dirPath must already exist (no mkdir here).
+// the returned function must be used to delete the lock.
+func WriteWithCustomLockPath(dirPath string, lockPath string, displayer loghelper.Displayer) func() {
 	for logLevel := hclog.Warn; true; logLevel = hclog.Info {
-		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL, fileperm.RW)
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, fileperm.RW)
 		if err == nil {
 			f.Close()
 

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -82,7 +82,7 @@ func TestParallelWriteRead(t *testing.T) {
 }
 
 func writeReadFile(dirPath string, filePath string, data []byte, displayer loghelper.Displayer) ([]byte, error) {
-	deleteLock := lockfile.WriteWithCustomLockPath(dirPath, filepath.Join(dirPath, ".lock"), displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(dirPath, ".", displayer)
 	defer deleteLock()
 
 	if err := os.WriteFile(filePath, data, fileperm.RW); err != nil {

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -82,7 +82,7 @@ func TestParallelWriteRead(t *testing.T) {
 }
 
 func writeReadFile(dirPath string, filePath string, data []byte, displayer loghelper.Displayer) ([]byte, error) {
-	deleteLock := lockfile.Write(dirPath, displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(dirPath, filepath.Join(dirPath, ".lock"), displayer)
 	defer deleteLock()
 
 	if err := os.WriteFile(filePath, data, fileperm.RW); err != nil {

--- a/versionmanager/manager.go
+++ b/versionmanager/manager.go
@@ -167,7 +167,7 @@ func (m VersionManager) InstallMultiple(ctx context.Context, versions []string) 
 		return err
 	}
 
-	deleteLock := lockfile.Write(installPath, m.Conf.Displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(installPath, filepath.Join(m.Conf.LockPath, m.FolderName+".lock"), m.Conf.Displayer)
 	disableExit := lockfile.CleanAndExitOnInterrupt(deleteLock)
 	defer disableExit()
 	defer deleteLock()
@@ -322,7 +322,7 @@ func (m VersionManager) Uninstall(requestedVersion string) error {
 		return err
 	}
 
-	deleteLock := lockfile.Write(installPath, m.Conf.Displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(installPath, filepath.Join(m.Conf.LockPath, m.FolderName+".lock"), m.Conf.Displayer)
 	disableExit := lockfile.CleanAndExitOnInterrupt(deleteLock)
 	defer disableExit()
 	defer deleteLock()
@@ -378,7 +378,7 @@ func (m VersionManager) UninstallMultiple(versions []string) error {
 		return err
 	}
 
-	deleteLock := lockfile.Write(installPath, m.Conf.Displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(installPath, filepath.Join(m.Conf.LockPath, m.FolderName+".lock"), m.Conf.Displayer)
 	disableExit := lockfile.CleanAndExitOnInterrupt(deleteLock)
 	defer disableExit()
 	defer deleteLock()
@@ -479,7 +479,7 @@ func (m VersionManager) installSpecificVersion(ctx context.Context, version stri
 		return nil
 	}
 
-	deleteLock := lockfile.Write(installPath, m.Conf.Displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(installPath, filepath.Join(m.Conf.LockPath, m.FolderName+".lock"), m.Conf.Displayer)
 	disableExit := lockfile.CleanAndExitOnInterrupt(deleteLock)
 	defer disableExit()
 	defer deleteLock()

--- a/versionmanager/manager.go
+++ b/versionmanager/manager.go
@@ -167,7 +167,7 @@ func (m VersionManager) InstallMultiple(ctx context.Context, versions []string) 
 		return err
 	}
 
-	deleteLock := lockfile.WriteWithCustomLockPath(installPath, filepath.Join(m.Conf.LockPath, m.FolderName+".lock"), m.Conf.Displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(m.Conf.LockPath, m.FolderName, m.Conf.Displayer)
 	disableExit := lockfile.CleanAndExitOnInterrupt(deleteLock)
 	defer disableExit()
 	defer deleteLock()
@@ -322,7 +322,7 @@ func (m VersionManager) Uninstall(requestedVersion string) error {
 		return err
 	}
 
-	deleteLock := lockfile.WriteWithCustomLockPath(installPath, filepath.Join(m.Conf.LockPath, m.FolderName+".lock"), m.Conf.Displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(m.Conf.LockPath, m.FolderName, m.Conf.Displayer)
 	disableExit := lockfile.CleanAndExitOnInterrupt(deleteLock)
 	defer disableExit()
 	defer deleteLock()
@@ -378,7 +378,7 @@ func (m VersionManager) UninstallMultiple(versions []string) error {
 		return err
 	}
 
-	deleteLock := lockfile.WriteWithCustomLockPath(installPath, filepath.Join(m.Conf.LockPath, m.FolderName+".lock"), m.Conf.Displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(m.Conf.LockPath, m.FolderName, m.Conf.Displayer)
 	disableExit := lockfile.CleanAndExitOnInterrupt(deleteLock)
 	defer disableExit()
 	defer deleteLock()
@@ -479,7 +479,7 @@ func (m VersionManager) installSpecificVersion(ctx context.Context, version stri
 		return nil
 	}
 
-	deleteLock := lockfile.WriteWithCustomLockPath(installPath, filepath.Join(m.Conf.LockPath, m.FolderName+".lock"), m.Conf.Displayer)
+	deleteLock := lockfile.WriteWithCustomLockPath(m.Conf.LockPath, m.FolderName, m.Conf.Displayer)
 	disableExit := lockfile.CleanAndExitOnInterrupt(deleteLock)
 	defer disableExit()
 	defer deleteLock()


### PR DESCRIPTION
**Description**
Added support for configuring a separate lock file location via the TENV_LOCK_PATH environment variable. When set, lock files are created in the specified directory instead of TENV_ROOT.

**Referenced Issue:** #480 

**Usage Examples**
```
# Default behavior (unchanged)
export TENV_ROOT=~/.tenv
tenv tf install 1.0.0

# Custom lock directory for S3 compatibility
export TENV_ROOT=/mnt/s3/tenv-versions
export TENV_LOCK_PATH=/tmp/tenv-locks
tenv tf install 1.0.0  # Creates /tmp/tenv-locks/tf.lock
```