### PR TITLE
Fixed the bug where an info message was polluting the stdout output.

### DIFF
--- a/pkg/cmdproxy/proxy.go
+++ b/pkg/cmdproxy/proxy.go
@@ -88,7 +88,7 @@ func initIO(cmd *exec.Cmd, pExitCode *int, gha bool, getenv configutils.GetenvFu
 	outputPath := getenv(envname.GithubOutput)
 	outputFile, err := os.OpenFile(outputPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, fileperm.RW)
 	if err != nil {
-		fmt.Println("Ignore GITHUB_ACTIONS, fail to open GITHUB_OUTPUT :", err) //nolint
+		fmt.Fprintf(os.Stderr, "Ignore GITHUB_ACTIONS, fail to open GITHUB_OUTPUT: %v\n", err) //nolint
 
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
**Description**
An stdout message where an info message was polluting the stdout output, is causing issues when trying to parse terraform output as JSON.

**Referenced Issue:** #286 