### PR TITLE
chore: bump alpine from 3.20 to 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN go build -ldflags="-s -w" -o atmos ./cmd/atmos \
     && go build -ldflags="-s -w" -o tf ./cmd/tf \
     && go build -ldflags="-s -w" -o tofu ./cmd/tofu
 
-FROM alpine:3.20
+FROM alpine:3.23
 LABEL maintainer="TofuUtils Core Team"
 
 RUN apk add --no-cache git bash openssh


### PR DESCRIPTION
bump alpine version, to get newer package version.

specifically github-cli, which is currently only available as 2.47.0, but would be available as [2.83.2-r2 with newest alpine version](https://pkgs.alpinelinux.org/package/edge/community/x86/github-cli). This would resolve this issue: 
- https://github.com/cli/cli/issues/11983