### PR TITLE
Fix panic in textui when no item is selected

### DIFF
--- a/cmd/tenv/textui.go
+++ b/cmd/tenv/textui.go
@@ -131,8 +131,6 @@ func (m itemSelector) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint
 
 		return m, nil
 	case tea.KeyMsg:
-		version := m.list.SelectedItem().FilterValue()
-
 		switch keypress := msg.String(); keypress {
 		case "ctrl+c", "esc", "q":
 			m.quitting = true
@@ -143,16 +141,20 @@ func (m itemSelector) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint
 		case "enter":
 			m.quitting = true
 
-			if len(m.choices) == 0 {
-				m.choices[version] = struct{}{}
+			selectedItem := m.list.SelectedItem()
+			if len(m.choices) == 0 && selectedItem != nil {
+				m.choices[selectedItem.FilterValue()] = struct{}{}
 			}
 
 			return m, tea.Quit
 		case " ":
-			if _, ok := m.choices[version]; ok {
-				delete(m.choices, version)
-			} else {
-				m.choices[version] = struct{}{}
+			if selectedItem := m.list.SelectedItem(); selectedItem != nil {
+				version := selectedItem.FilterValue()
+				if _, ok := m.choices[version]; ok {
+					delete(m.choices, version)
+				} else {
+					m.choices[version] = struct{}{}
+				}
 			}
 
 			return m, nil


### PR DESCRIPTION
Fixes #566

The issue was that we were calling `SelectedItem().FilterValue()` without checking if the item was nil first. When exiting uninstall with nothing selected, this would panic.

Moved the item selection check inline and only call `FilterValue()` after verifying the item exists. This way we skip the add/remove logic if there's nothing selected, which is the right behavior anyway.