### PR TITLE
Include unexpected value in apimsg.ErrReturn errors

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -21,6 +21,7 @@ package github
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -56,7 +57,7 @@ func AssetDownloadURL(ctx context.Context, tag string, searchedAssetNames []stri
 	object, _ := value.(map[string]any)
 	baseAssetsURL, ok := object["assets_url"].(string)
 	if !ok {
-		return nil, apimsg.ErrReturn
+		return nil, fmt.Errorf("%w: missing or non-string 'assets_url' field in release response: %v", apimsg.ErrReturn, value)
 	}
 
 	waited := len(searchedAssetNames)
@@ -142,7 +143,7 @@ func buildAuthorizationHeader(token string) string {
 func extractAssets(assets map[string]string, searchedAssetNameSet map[string]struct{}, waited int, value any) error {
 	values, ok := value.([]any)
 	if !ok {
-		return apimsg.ErrReturn
+		return fmt.Errorf("%w: expected a JSON array of assets, got %T: %v", apimsg.ErrReturn, value, value)
 	}
 
 	if len(values) == 0 {
@@ -153,7 +154,7 @@ func extractAssets(assets map[string]string, searchedAssetNameSet map[string]str
 		object, _ := value.(map[string]any)
 		assetName, ok := object["name"].(string) //nolint
 		if !ok {
-			return apimsg.ErrReturn
+			return fmt.Errorf("%w: missing or non-string 'name' field in asset: %v", apimsg.ErrReturn, object)
 		}
 
 		if _, ok := searchedAssetNameSet[assetName]; !ok {
@@ -162,7 +163,7 @@ func extractAssets(assets map[string]string, searchedAssetNameSet map[string]str
 
 		downloadURL, ok := object["browser_download_url"].(string)
 		if !ok {
-			return apimsg.ErrReturn
+			return fmt.Errorf("%w: missing or non-string 'browser_download_url' field for asset %q: %v", apimsg.ErrReturn, assetName, object)
 		}
 		assets[assetName] = downloadURL
 
@@ -177,7 +178,7 @@ func extractAssets(assets map[string]string, searchedAssetNameSet map[string]str
 func extractReleases(releases []string, value any) ([]string, error) {
 	values, ok := value.([]any)
 	if !ok {
-		return nil, apimsg.ErrReturn
+		return nil, fmt.Errorf("%w: expected a JSON array of releases, got %T: %v", apimsg.ErrReturn, value, value)
 	}
 
 	if len(values) == 0 {
@@ -187,7 +188,7 @@ func extractReleases(releases []string, value any) ([]string, error) {
 	for _, value := range values {
 		version := extractVersion(value)
 		if version == "" {
-			return nil, apimsg.ErrReturn
+			return nil, fmt.Errorf("%w: could not extract a version from release entry: %v", apimsg.ErrReturn, value)
 		}
 		releases = append(releases, version)
 	}

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/tofuutils/tenv/v4/pkg/apimsg"
@@ -153,4 +154,94 @@ func TestExtractVersion(t *testing.T) {
 	if version != "1.6.0" {
 		t.Error("Unmatching result, get :", version)
 	}
+}
+
+// new test func's for MalformedData
+func TestExtractAssetsMalformedData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NotAnArray", func(t *testing.T) {
+		t.Parallel()
+
+		assets := map[string]string{}
+		searchedAssetNames := map[string]struct{}{"tofu_1.6.0_386.deb": {}}
+		err := extractAssets(assets, searchedAssetNames, 1, "not an array")
+		if err == nil {
+			t.Fatal("Should fail on non-array value")
+		}
+		if !errors.Is(err, apimsg.ErrReturn) {
+			t.Error("Expected wrapped apimsg.ErrReturn, got :", err)
+		}
+		if !strings.Contains(err.Error(), "not an array") {
+			t.Error("Expected error message to contain the unexpected value, got :", err)
+		}
+	})
+
+	t.Run("MissingNameField", func(t *testing.T) {
+		t.Parallel()
+
+		assets := map[string]string{}
+		searchedAssetNames := map[string]struct{}{"tofu_1.6.0_386.deb": {}}
+		badValue := []any{map[string]any{"browser_download_url": "https://example.com/file"}}
+		err := extractAssets(assets, searchedAssetNames, 1, badValue)
+		if err == nil {
+			t.Fatal("Should fail on missing 'name' field")
+		}
+		if !errors.Is(err, apimsg.ErrReturn) {
+			t.Error("Expected wrapped apimsg.ErrReturn, got :", err)
+		}
+		if !strings.Contains(err.Error(), "name") {
+			t.Error("Expected error message to mention the missing 'name' field, got :", err)
+		}
+	})
+
+	t.Run("MissingDownloadURLField", func(t *testing.T) {
+		t.Parallel()
+
+		assets := map[string]string{}
+		searchedAssetNames := map[string]struct{}{"tofu_1.6.0_386.deb": {}}
+		badValue := []any{map[string]any{"name": "tofu_1.6.0_386.deb"}}
+		err := extractAssets(assets, searchedAssetNames, 1, badValue)
+		if err == nil {
+			t.Fatal("Should fail on missing 'browser_download_url' field")
+		}
+		if !errors.Is(err, apimsg.ErrReturn) {
+			t.Error("Expected wrapped apimsg.ErrReturn, got :", err)
+		}
+		if !strings.Contains(err.Error(), "browser_download_url") {
+			t.Error("Expected error message to mention the missing field, got :", err)
+		}
+	})
+}
+
+func TestExtractReleasesMalformedData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NotAnArray", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := extractReleases(nil, 42)
+		if err == nil {
+			t.Fatal("Should fail on non-array value")
+		}
+		if !errors.Is(err, apimsg.ErrReturn) {
+			t.Error("Expected wrapped apimsg.ErrReturn, got :", err)
+		}
+		if !strings.Contains(err.Error(), "42") {
+			t.Error("Expected error message to contain the unexpected value, got :", err)
+		}
+	})
+
+	t.Run("UnparseableVersion", func(t *testing.T) {
+		t.Parallel()
+
+		badValue := []any{map[string]any{"tag_name": ""}}
+		_, err := extractReleases(nil, badValue)
+		if err == nil {
+			t.Fatal("Should fail when no version can be extracted")
+		}
+		if !errors.Is(err, apimsg.ErrReturn) {
+			t.Error("Expected wrapped apimsg.ErrReturn, got :", err)
+		}
+	})
 }

--- a/versionmanager/retriever/terraform/api/releaseapi.go
+++ b/versionmanager/retriever/terraform/api/releaseapi.go
@@ -18,7 +18,10 @@
 
 package releaseapi
 
-import "github.com/tofuutils/tenv/v4/pkg/apimsg"
+import (
+	"fmt"
+	"github.com/tofuutils/tenv/v4/pkg/apimsg"
+)
 
 func ExtractAssetURLs(searchedOs string, searchedArch string, value any) (string, string, string, string, error) {
 	object, _ := value.(map[string]any)
@@ -26,7 +29,7 @@ func ExtractAssetURLs(searchedOs string, searchedArch string, value any) (string
 	shaFileName, ok2 := object["shasums"].(string)
 	shaSigFileName, ok3 := object["shasums_signature"].(string)
 	if !ok || !ok2 || !ok3 {
-		return "", "", "", "", apimsg.ErrReturn
+		return "", "", "", "", fmt.Errorf("%w: missing or invalid 'builds', 'shasums', or 'shasums_signature' field in release response: %v", apimsg.ErrReturn, object)
 	}
 
 	for _, build := range builds {
@@ -36,7 +39,7 @@ func ExtractAssetURLs(searchedOs string, searchedArch string, value any) (string
 		downloadURL, ok3 := object["url"].(string)
 		fileName, ok4 := object["filename"].(string)
 		if !ok || !ok2 || !ok3 || !ok4 {
-			return "", "", "", "", apimsg.ErrReturn
+			return "", "", "", "", fmt.Errorf("%w: missing or invalid os/arch/url/filename field in build entry: %v", apimsg.ErrReturn, object)
 		}
 
 		if osStr != searchedOs || archStr != searchedArch {
@@ -53,7 +56,7 @@ func ExtractReleases(value any) ([]string, error) {
 	object, _ := value.(map[string]any)
 	versions, ok := object["versions"].(map[string]any)
 	if !ok {
-		return nil, apimsg.ErrReturn
+		return nil, fmt.Errorf("%w: missing or non-object 'versions' field in response: %v", apimsg.ErrReturn, object)
 	}
 
 	releases := make([]string, 0, len(object))

--- a/versionmanager/retriever/tofu/dl/tofudl.go
+++ b/versionmanager/retriever/tofu/dl/tofudl.go
@@ -19,6 +19,7 @@
 package tofudlmirroring
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -58,7 +59,7 @@ func ExtractReleases(value any) ([]string, error) {
 	object, _ := value.(map[string]any)
 	versions, ok := object["versions"].([]any)
 	if !ok {
-		return nil, apimsg.ErrReturn
+		return nil, fmt.Errorf("%w: missing or non-array 'versions' field in response: %v", apimsg.ErrReturn, object)
 	}
 
 	releases := make([]string, 0, len(object))
@@ -67,7 +68,7 @@ func ExtractReleases(value any) ([]string, error) {
 		versionID := castedVersionDesc["id"]
 		version, ok := versionID.(string)
 		if !ok {
-			return nil, apimsg.ErrReturn
+			return nil, fmt.Errorf("%w: missing or non-string 'id' field in version entry: %v", apimsg.ErrReturn, castedVersionDesc)
 		}
 
 		releases = append(releases, version)


### PR DESCRIPTION
## What this does

All call sites that return `apimsg.ErrReturn` previously discarded the
actual malformed value and the specific field that failed validation,
making it impossible to diagnose intermittent "unexpected value
returned by API" errors from logs alone — exactly the problem reported
in #558.

This PR wraps `apimsg.ErrReturn` with `fmt.Errorf("%w: ...", ...)` at
each of the 7 affected call sites across:
- `pkg/github/github.go`
- `versionmanager/retriever/terraform/api/releaseapi.go`
- `versionmanager/retriever/tofu/dl/tofudl.go`

Each wrapped error now includes the specific field that failed
validation and the actual unexpected value received, while preserving
`errors.Is(err, apimsg.ErrReturn)` compatibility for any existing
callers that check for this sentinel.

## Testing

Added new subtests (`TestExtractAssetsMalformedData`,
`TestExtractReleasesMalformedData`) in `pkg/github/github_test.go`
covering the malformed-input paths that previously had no test
coverage. All existing tests continue to pass.

ok  github.com/tofuutils/tenv/v4/pkg/github               4.743s

ok  github.com/tofuutils/tenv/v4/versionmanager/retriever/terraform/api   3.180s

ok  github.com/tofuutils/tenv/v4/versionmanager/retriever/tofu            3.005s

Note: `pkg/uncompress/sanitize` has a pre-existing test failure on
Windows unrelated to this change (path separator mismatch in test
expectations) — confirmed via `git stash` that it fails identically
on `main` without these changes.

Fixes #558