### PR TITLE
fix: return an error when uninstalling a non-installed version

### DIFF
--- a/versionmanager/manager.go
+++ b/versionmanager/manager.go
@@ -346,6 +346,7 @@ func (m VersionManager) Uninstall(requestedVersion string) error {
 
 	if versionfinder.IsValid(requestedVersion) {
 		cleanedVersion := versionfinder.Clean(requestedVersion)
+
 		return m.uninstallSpecificVersion(installPath, cleanedVersion)
 	}
 
@@ -568,15 +569,18 @@ func (m VersionManager) uninstallSpecificVersion(installPath string, version str
 		if errors.Is(err, os.ErrNotExist) {
 			msg := loghelper.Concat(m.FolderName, " ", version, " is not installed")
 			m.Conf.Displayer.Display(msg)
+
 			return fmt.Errorf("%w: %s", errVersionNotInstalled, msg)
 		}
 
 		m.Conf.Displayer.Display(loghelper.Concat("Uninstallation of ", m.FolderName, " ", version, " failed with error : ", err.Error()))
+
 		return err
 	}
 
 	if err := os.RemoveAll(targetPath); err != nil {
 		m.Conf.Displayer.Display(loghelper.Concat("Uninstallation of ", m.FolderName, " ", version, " failed with error : ", err.Error()))
+
 		return err
 	}
 

--- a/versionmanager/manager.go
+++ b/versionmanager/manager.go
@@ -21,6 +21,7 @@ package versionmanager
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -46,6 +47,7 @@ import (
 
 var (
 	errEmptyVersion        = errors.New("empty version")
+	errVersionNotInstalled = errors.New("version is not installed")
 	errNoCompatible        = errors.New("no compatible version found")
 	ErrNoCompatibleLocally = errors.New("no compatible version found locally")
 	ErrNoVersionFilesFound = errors.New("no version files found")
@@ -344,9 +346,7 @@ func (m VersionManager) Uninstall(requestedVersion string) error {
 
 	if versionfinder.IsValid(requestedVersion) {
 		cleanedVersion := versionfinder.Clean(requestedVersion)
-		m.uninstallSpecificVersion(installPath, cleanedVersion)
-
-		return nil
+		return m.uninstallSpecificVersion(installPath, cleanedVersion)
 	}
 
 	versions, err := m.innerListLocal(installPath, true)
@@ -362,7 +362,7 @@ func (m VersionManager) Uninstall(requestedVersion string) error {
 	if len(selected) == 0 {
 		m.Conf.Displayer.Display(loghelper.Concat("No matching ", m.FolderName, " versions"))
 
-		return nil
+		return errVersionNotInstalled
 	}
 
 	m.Conf.Displayer.Display(loghelper.Concat("Selected ", m.FolderName, " versions for uninstallation :"))
@@ -380,11 +380,14 @@ func (m VersionManager) Uninstall(requestedVersion string) error {
 		return nil
 	}
 
+	var errs []error
 	for _, version := range selected {
-		m.uninstallSpecificVersion(installPath, version)
+		if err := m.uninstallSpecificVersion(installPath, version); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (m VersionManager) UninstallMultiple(versions []string) error {
@@ -398,11 +401,14 @@ func (m VersionManager) UninstallMultiple(versions []string) error {
 	defer disableExit()
 	defer deleteLock()
 
+	var errs []error
 	for _, version := range versions {
-		m.uninstallSpecificVersion(installPath, version)
+		if err := m.uninstallSpecificVersion(installPath, version); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (m VersionManager) Use(ctx context.Context, requestedVersion string, workingDir bool) error {
@@ -550,20 +556,33 @@ func (m VersionManager) searchInstallRemote(ctx context.Context, predicateInfo t
 	return "", errNoCompatible
 }
 
-func (m VersionManager) uninstallSpecificVersion(installPath string, version string) {
+func (m VersionManager) uninstallSpecificVersion(installPath string, version string) error {
 	if version == "" {
 		m.Conf.Displayer.Display(errEmptyVersion.Error())
 
-		return
+		return errEmptyVersion
 	}
 
 	targetPath := filepath.Join(installPath, version)
-	err := os.RemoveAll(targetPath)
-	if err == nil {
-		m.Conf.Displayer.Display(loghelper.Concat("Uninstallation of ", m.FolderName, " ", version, " successful (directory ", targetPath, " removed)"))
-	} else {
+	if _, err := os.Stat(targetPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			msg := loghelper.Concat(m.FolderName, " ", version, " is not installed")
+			m.Conf.Displayer.Display(msg)
+			return fmt.Errorf("%w: %s", errVersionNotInstalled, msg)
+		}
+
 		m.Conf.Displayer.Display(loghelper.Concat("Uninstallation of ", m.FolderName, " ", version, " failed with error : ", err.Error()))
+		return err
 	}
+
+	if err := os.RemoveAll(targetPath); err != nil {
+		m.Conf.Displayer.Display(loghelper.Concat("Uninstallation of ", m.FolderName, " ", version, " failed with error : ", err.Error()))
+		return err
+	}
+
+	m.Conf.Displayer.Display(loghelper.Concat("Uninstallation of ", m.FolderName, " ", version, " successful (directory ", targetPath, " removed)"))
+
+	return nil
 }
 
 func removeFile(filePath string, conf *config.Config) error {

--- a/versionmanager/tenvlib/lib.go
+++ b/versionmanager/tenvlib/lib.go
@@ -310,7 +310,7 @@ func (t Tenv) Uninstall(_ context.Context, toolName string, requestedVersion str
 		return err
 	}
 
-	return manager.UninstallMultiple([]string{requestedVersion})
+	return manager.Uninstall(requestedVersion)
 }
 
 func (t Tenv) UninstallMultiple(_ context.Context, toolName string, versions []string) error {

--- a/versionmanager/uninstall_test.go
+++ b/versionmanager/uninstall_test.go
@@ -1,0 +1,149 @@
+package versionmanager
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tofuutils/tenv/v4/config"
+	terraformretriever "github.com/tofuutils/tenv/v4/versionmanager/retriever/terraform"
+)
+
+func errsFromJoin(err error) []error {
+	type joinError interface{ Unwrap() []error }
+
+	var jerr joinError
+	if !errors.As(err, &jerr) {
+		return nil
+	}
+
+	return jerr.Unwrap()
+}
+
+func buildManager(t *testing.T, toolFolder string) VersionManager {
+	t.Helper()
+
+	conf, confErr := config.DefaultConfig()
+	if confErr != nil {
+		t.Fatal(confErr)
+	}
+
+	conf.RootPath = t.TempDir()
+	conf.LockPath = conf.RootPath
+	conf.InitDisplayer(false)
+
+	return Make(&conf, "", toolFolder, nil, terraformretriever.Make(&conf), nil)
+}
+
+func TestUninstall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Uninstall_not_installed_exact_version", func(t *testing.T) {
+		t.Parallel()
+
+		mgr := buildManager(t, "Terraform")
+		uninstallErr := mgr.Uninstall("1.0.0")
+		if uninstallErr == nil {
+			t.Fatal("expected error when uninstalling a version that is not installed, got nil")
+		}
+
+		if !errors.Is(uninstallErr, errVersionNotInstalled) {
+			t.Errorf("expected errVersionNotInstalled, got: %v", uninstallErr)
+		}
+	})
+
+	t.Run("UninstallMultiple_returns_error_for_not_installed", func(t *testing.T) {
+		t.Parallel()
+
+		mgr := buildManager(t, "Terraform")
+		uninstallErr := mgr.UninstallMultiple([]string{"1.0.0"})
+		if uninstallErr == nil {
+			t.Fatal("expected error when uninstalling a version that is not installed, got nil")
+		}
+
+		if !errors.Is(uninstallErr, errVersionNotInstalled) {
+			t.Errorf("expected errVersionNotInstalled, got: %v", uninstallErr)
+		}
+	})
+
+	t.Run("UninstallMultiple_returns_joined_errors_for_multiple_not_installed", func(t *testing.T) {
+		t.Parallel()
+
+		mgr := buildManager(t, "OpenTofu")
+		uninstallErr := mgr.UninstallMultiple([]string{"1.0.0", "1.1.0"})
+		if uninstallErr == nil {
+			t.Fatal("expected error when uninstalling versions that are not installed, got nil")
+		}
+
+		unwrapped := errsFromJoin(uninstallErr)
+		if unwrapped == nil || len(unwrapped) == 0 {
+			t.Fatal("expected joined error with at least one wrapped error")
+		}
+
+		found := false
+		for _, u := range unwrapped {
+			if errors.Is(u, errVersionNotInstalled) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			t.Errorf("expected errVersionNotInstalled wrapped in joined error, got: %v", uninstallErr)
+		}
+	})
+
+	t.Run("Uninstall_installed_version_succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		mgr := buildManager(t, "Terraform")
+		installPath, pathErr := mgr.InstallPath()
+		if pathErr != nil {
+			t.Fatal(pathErr)
+		}
+
+		versionDir := filepath.Join(installPath, "1.2.3")
+		if mkdirErr := os.MkdirAll(versionDir, 0o755); mkdirErr != nil {
+			t.Fatal(mkdirErr)
+		}
+
+		uninstallErr := mgr.Uninstall("1.2.3")
+		if uninstallErr != nil {
+			t.Fatalf("unexpected error uninstalling installed version: %v", uninstallErr)
+		}
+
+		if _, statErr := os.Stat(versionDir); !os.IsNotExist(statErr) {
+			t.Error("expected version directory to be removed after uninstall")
+		}
+	})
+
+	t.Run("Uninstall_same_version_twice_returns_error", func(t *testing.T) {
+		t.Parallel()
+
+		mgr := buildManager(t, "Terragrunt")
+		installPath, pathErr := mgr.InstallPath()
+		if pathErr != nil {
+			t.Fatal(pathErr)
+		}
+
+		versionDir := filepath.Join(installPath, "0.49.0")
+		if mkdirErr := os.MkdirAll(versionDir, 0o755); mkdirErr != nil {
+			t.Fatal(mkdirErr)
+		}
+
+		firstErr := mgr.Uninstall("0.49.0")
+		if firstErr != nil {
+			t.Fatalf("first uninstall should succeed, got: %v", firstErr)
+		}
+
+		secondErr := mgr.Uninstall("0.49.0")
+		if secondErr == nil {
+			t.Fatal("expected error on second uninstall of already-removed version, got nil")
+		}
+
+		if !errors.Is(secondErr, errVersionNotInstalled) {
+			t.Errorf("expected errVersionNotInstalled on second uninstall, got: %v", secondErr)
+		}
+	})
+}

--- a/versionmanager/uninstall_test.go
+++ b/versionmanager/uninstall_test.go
@@ -77,7 +77,7 @@ func TestUninstall(t *testing.T) {
 		}
 
 		unwrapped := errsFromJoin(uninstallErr)
-		if unwrapped == nil || len(unwrapped) == 0 {
+		if len(unwrapped) == 0 {
 			t.Fatal("expected joined error with at least one wrapped error")
 		}
 
@@ -85,6 +85,7 @@ func TestUninstall(t *testing.T) {
 		for _, u := range unwrapped {
 			if errors.Is(u, errVersionNotInstalled) {
 				found = true
+
 				break
 			}
 		}


### PR DESCRIPTION
### Summary

solves #616 

`tenv <tool> uninstall <version>` used to silently report success when the requested version was not installed locally. This change makes it return a clear `<Tool> <version> is not installed` error and a non-zero exit code, matching the documented expected behaviour.

Fixes the bug described for `tf`, `tofu`, `tg` (and `tm`) where running

```
tenv <tool> uninstall 0.0.0
```

reported `Uninstallation of <Tool> 0.0.0 successful (directory … removed)` even though the version does not exist.

#### What this PR fixes

`uninstallSpecificVersion` in `versionmanager/manager.go` relied on `os.RemoveAll`, which is a no-op on a non-existent path and returns `nil`. Callers therefore reported success even when nothing was installed for the requested version.

#### Implementation

`versionmanager/manager.go`

- New sentinel `errVersionNotInstalled` exported package-wide.
- `uninstallSpecificVersion` stats the target directory first; missing path -> display the user-facing message and return wrapped `errVersionNotInstalled`; otherwise `os.RemoveAll` and only report success when it actually removes something.
- `Uninstall` propagates the error in both branches: exact version and the constraint path (when `SelectVersionsToUninstall` yields an empty selection).
- `UninstallMultiple` and the multi-version loop in `Uninstall` collect per-version errors via `errors.Join`.

`versionmanager/tenvlib/lib.go`

- `Tenv.Uninstall` now delegates to `manager.Uninstall(requestedVersion)` instead of `UninstallMultiple([]string{requestedVersion})`, routing the single-version CLI path through the direct, non-interactive branch and ensuring the new error reaches callers.

#### Tests

`versionmanager/uninstall_test.go` *(new)*:

- `Uninstall_not_installed_exact_version` -- original bug.
- `UninstallMultiple_returns_error_for_not_installed`.
- `UninstallMultiple_returns_joined_errors_for_multiple_not_installed` -- verifies `errors.Join` wrapping.
- `Uninstall_installed_version_succeeds` -- happy path regression.
- `Uninstall_same_version_twice_returns_error` -- idempotency.

### Commits

This PR is split into two commits to keep history readable:

1. `fix(uninstall): return an error when the target version is not installed` -- manager logic + tests.
2. `fix(tenvlib): route single-version Uninstall through VersionManager.Uninstall` -- public-API routing.

### Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l versionmanager/` clean
- [x] `go test ./versionmanager/... ./versionmanager/tenvlib/...` -- all new subtests pass; no regressions in existing suites.
